### PR TITLE
small fix for example code

### DIFF
--- a/examples/redis-initialize.php
+++ b/examples/redis-initialize.php
@@ -2,7 +2,6 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use Qandidate\Toggle\Context;
 use Qandidate\Toggle\Operator\LessThan;
 use Qandidate\Toggle\OperatorCondition;
 use Qandidate\Toggle\Toggle;

--- a/examples/redis-use.php
+++ b/examples/redis-use.php
@@ -2,11 +2,7 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use Predis\Client;
 use Qandidate\Toggle\Context;
-use Qandidate\Toggle\Operator\LessThan;
-use Qandidate\Toggle\OperatorCondition;
-use Qandidate\Toggle\Toggle;
 use Qandidate\Toggle\ToggleCollection\PredisCollection;
 use Qandidate\Toggle\ToggleManager;
 


### PR DESCRIPTION
I ran into this problem when trying to run the examples... redis-initialize and redis-use set different namespaces for the PredisCollection, so the example didn't run correctly.

Also, for the sake of clarity I removed the unnecessary `use` statements from the redis example files.
