### PR TITLE
Adding update method to ToggleCollection abstract class

### DIFF
--- a/lib/Qandidate/Toggle/ToggleCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection.php
@@ -39,6 +39,12 @@ abstract class ToggleCollection
 
     /**
      * @param string $name
+     * @param Toggle $toggle
+     */
+    abstract public function update($name, Toggle $toggle);
+
+    /**
+     * @param string $name
      *
      * @return boolean True, if element was removed
      */

--- a/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
@@ -53,6 +53,14 @@ class InMemoryCollection extends ToggleCollection
     /**
      * {@inheritDoc}
      */
+    public function update($name, Toggle $toggle)
+    {
+        $this->set($name, $toggle);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function remove($name)
     {
         if ( ! array_key_exists($name, $this->toggles)) {

--- a/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
@@ -67,6 +67,14 @@ class PredisCollection extends ToggleCollection
     /**
      * {@inheritDoc}
      */
+    public function update($name, Toggle $toggle)
+    {
+        $this->set($name, $toggle);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function remove($name)
     {
         return 1 === $this->client->del($this->namespace . '__TOGGLE__' . $name);

--- a/lib/Qandidate/Toggle/ToggleManager.php
+++ b/lib/Qandidate/Toggle/ToggleManager.php
@@ -68,9 +68,13 @@ class ToggleManager
      *
      * @param Toggle $toggle
      */
-    public function update(Toggle $toggle)
+    public function update(Toggle $toggle, $name = null)
     {
-        $this->collection->set($toggle->getName(), $toggle);
+        if(is_null($name)) {
+            $name = $toggle->getName();
+        }
+
+        $this->collection->update($name, $toggle);
     }
 
     /**

--- a/test/Qandidate/Toggle/ToggleCollectionTest.php
+++ b/test/Qandidate/Toggle/ToggleCollectionTest.php
@@ -40,6 +40,18 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_a_updated_toggle()
+    {
+        $toggle     = new Toggle('some-feature', array());
+        $collection = $this->createCollection();
+        $collection->update($toggle->getName(), $toggle);
+
+        $this->assertEquals($toggle, $collection->get('some-feature'));
+    }
+
+    /**
+     * @test
+     */
     public function it_removes_a_toggle()
     {
         $toggle     = new Toggle('some-feature', array());


### PR DESCRIPTION
I found a workaround to not having an update method in ToggleCollection, but I really don't like workarounds. My application is using Redis and needs an easy way to detect when a toggle name is changed so I can delete the old record and use the new name when getting the toggle.

Workaround:

``` php
//class AppCollection extends ToggleCollection
//...
public function set( $name, Toggle $toggle ) {
    $remove = false;
    $removeName = $name;
    $trace = debug_backtrace();
    $caller = $trace[1];

    if( strstr( $caller[ 'function' ] , 'update' ) ) {
        extract( $this->checkNameChange( $name , $toggle ) ); //returns [ 'name' => $name , 'toggle' => $this->serializer->deserialize( $toggle ) , 'remove' => $remove ]
        if( $remove ) $this->remove( $removeName );
    }
    $this->client->set( $this->namespace . '__TOGGLE__' . $name, serialize( $toggle ) );
}
//...
```

ToggleCollection will then also have 'GET' (get), 'POST' (set), 'PUT' (update), and 'DELETE' (remove) methods.
