### PR TITLE
Added InMemoryFactory to build Collections from array with examples

### DIFF
--- a/examples/from-array.php
+++ b/examples/from-array.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Qandidate\Toggle\Context;
+use Qandidate\Toggle\ToggleManager;
+use Qandidate\Toggle\Serializer\InMemoryCollectionSerializer;
+
+// Array value
+$data = array(
+    'some-feature' => array(
+        'name' => 'toggling',
+        'conditions' => array(
+            array(
+                'name' => 'operator-condition',
+                'key' => 'user_id',
+                'operator' => array('name' => 'greater-than', 'value' => 41),
+            ),
+        ),
+        'status' => 'conditionally-active',
+    ),
+);
+
+// Create the ToggleManager
+$serializer = new InMemoryCollectionSerializer();
+$collection = $serializer->deserialize($data);
+$manager    = new ToggleManager($collection);
+
+// Create and check a new context for a user with id 42
+$context = new Context();
+$context->set('user_id', 42);
+var_dump($manager->active('some-feature', $context)); // true
+
+// Create and check a new context for a user with id 21
+$context = new Context();
+$context->set('user_id', 21);
+var_dump($manager->active('some-feature', $context)); // false

--- a/examples/from-yaml.php
+++ b/examples/from-yaml.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Symfony\Component\Yaml\Yaml;
+use Qandidate\Toggle\Context;
+use Qandidate\Toggle\ToggleManager;
+use Qandidate\Toggle\Serializer\InMemoryCollectionSerializer;
+
+/**
+ * To parse yml files, make sure you install symfony/yaml otherwise this example won't work. This can be achieved by:
+ *
+ * $ composer require symfony/yaml
+ */
+
+$yaml = <<<YML
+toggles:
+  - name: some-feature
+    conditions:
+     - name: operator-condition
+       key: user_id
+       operator:
+           name: greater-than
+           value: 41
+       status: conditionally-active
+  - name: some-feature2
+    conditions:
+     - name: operator-condition
+       key: user_id
+       operator:
+           name: greater-than
+           value: 42
+       status: conditionally-active
+YML;
+
+// Create the ToggleManager
+$array      = Yaml::parse($yaml);
+$serializer = new InMemoryCollectionSerializer();
+$collection = $serializer->deserialize($array);
+$manager    = new ToggleManager($collection);
+
+// Create and check a new context for a user with id 42
+$context = new Context();
+$context->set('user_id', 42);
+var_dump($manager->active('some-feature', $context)); // true
+
+// Create and check a new context for a user with id 21
+$context = new Context();
+$context->set('user_id', 21);
+var_dump($manager->active('some-feature', $context)); // false

--- a/lib/Qandidate/Toggle/Serializer/InMemoryCollectionSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/InMemoryCollectionSerializer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Qandidate\Toggle\Serializer;
+
+use Qandidate\Toggle\ToggleCollection\InMemoryCollection;
+
+class InMemoryCollectionSerializer
+{
+    /**
+     * @param array $data
+     * @return InMemoryCollection
+     */
+    public function deserialize(array $data)
+    {
+        $collection = new InMemoryCollection();
+        $serializer = new ToggleSerializer(new OperatorConditionSerializer(new OperatorSerializer()));
+
+        foreach ($data as $name => $serializedToggle) {
+            $toggle = $serializer->deserialize($serializedToggle);
+            $collection->set($name, $toggle);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * @param InMemoryCollection $toggleCollection
+     * @return array
+     */
+    public function serialize(InMemoryCollection $toggleCollection)
+    {
+        $serializer = new ToggleSerializer(new OperatorConditionSerializer(new OperatorSerializer()));
+        $ret = array();
+        foreach ($toggleCollection->all() as $key => $toggle) {
+            $ret[$key] = $serializer->serialize($toggle);
+        }
+
+        return $ret;
+    }
+}

--- a/test/Qandidate/Toggle/Serializer/InMemoryCollectionSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/InMemoryCollectionSerializerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Qandidate\Toggle\ToggleCollection;
+
+use Qandidate\Toggle\Operator\LessThan;
+use Qandidate\Toggle\OperatorCondition;
+use Qandidate\Toggle\Serializer\InMemoryCollectionSerializer;
+use Qandidate\Toggle\TestCase;
+use Qandidate\Toggle\Toggle;
+
+class InMemoryCollectionSerializerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_unserializes_a_collection_from_an_array()
+    {
+        $data = array(
+            'some-feature' => array(
+                'name' => 'toggling',
+                'conditions' => array(
+                    array(
+                        'name' => 'operator-condition',
+                        'key' => 'user_id',
+                        'operator' => array('name' => 'greater-than', 'value' => 42),
+                    ),
+                ),
+                'status' => 'conditionally-active',
+            ),
+        );
+
+        $serializer = new InMemoryCollectionSerializer();
+        $collection = $serializer->deserialize($data);
+
+        $this->assertInstanceOf('Qandidate\Toggle\Toggle', $collection->get('some-feature'));
+        $this->assertCount(1, $collection->all());
+    }
+
+    /**
+     * @test
+     */
+    public function it_serializes_a_collection_to_an_array()
+    {
+        $collection = new InMemoryCollection();
+        $operator   = new LessThan(42);
+        $condition  = new OperatorCondition('user_id', $operator);
+        $toggle     = new Toggle('toggling', array($condition));
+        $collection->set('some-feature', $toggle);
+        $serializer = new InMemoryCollectionSerializer();
+
+        $serialized = $serializer->serialize($collection);
+
+        $this->assertInternalType('array', $serialized);
+        $this->assertArrayHasKey('some-feature', $serialized);
+        $this->assertArrayHasKey('name', $serialized['some-feature']);
+        $this->assertArrayHasKey('conditions', $serialized['some-feature']);
+        $this->assertSame('toggling', $serialized['some-feature']['name']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_serializes_and_deserializes_a_collection()
+    {
+        $collection = new InMemoryCollection();
+        $operator   = new LessThan(42);
+        $condition  = new OperatorCondition('user_id', $operator);
+        $toggle     = new Toggle('toggling', array($condition));
+        $collection->set('some-feature', $toggle);
+        $serializer = new InMemoryCollectionSerializer();
+
+        $serialized = $serializer->serialize($collection);
+        $collection2 = $serializer->deserialize($serialized);
+
+        $this->assertEquals($collection, $collection2);
+    }
+}


### PR DESCRIPTION
Hi @asm89

Instead of creating a YmlCollection I thought I would make more sense to delegate the creation of a collection based on an array to a <code>InMemoryCollectionFactory</code>. Users are free to create an array from whatever source (Yaml example supplied).

I'm open for feedback or improvements. Merging is also fine of course :).

 