### PR TITLE
Feature condition strategies

### DIFF
--- a/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
@@ -38,11 +38,8 @@ class ToggleSerializer
             'name' => $toggle->getName(),
             'conditions' => $this->serializeConditions($toggle->getConditions()),
             'status' => $this->serializeStatus($toggle),
+            'strategy' => $this->serializeStrategy($toggle),
         );
-
-        if ($toggle->getStrategy() != Toggle::STRATEGY_AFFIRMATIVE) {
-            $serialized['strategy'] = $this->serializeStrategy($toggle);
-        }
 
         return $serialized;
     }

--- a/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
@@ -34,11 +34,17 @@ class ToggleSerializer
      */
     public function serialize(Toggle $toggle)
     {
-        return array(
+        $serialized = array(
             'name' => $toggle->getName(),
             'conditions' => $this->serializeConditions($toggle->getConditions()),
             'status' => $this->serializeStatus($toggle),
         );
+
+        if ($toggle->getStrategy() != Toggle::STRATEGY_AFFIRMATIVE) {
+            $serialized['strategy'] = $this->serializeStrategy($toggle);
+        }
+
+        return $serialized;
     }
 
     /**
@@ -55,9 +61,15 @@ class ToggleSerializer
             throw new RuntimeException('Key "conditions" should be an array.');
         }
 
+        $strategy = Toggle::STRATEGY_AFFIRMATIVE;
+        if (isset($data['strategy'])) {
+            $strategy = $this->deserializeStrategy($data['strategy']);
+        }
+
         $toggle = new Toggle(
             $data['name'],
-            $this->deserializeConditions($data['conditions'])
+            $this->deserializeConditions($data['conditions']),
+            $strategy
         );
 
         if (isset($data['status'])) {
@@ -120,6 +132,32 @@ class ToggleSerializer
         }
 
         throw new RuntimeException(sprintf('Unknown toggle status "%s".', $status));
+    }
+
+    private function serializeStrategy(Toggle $toggle)
+    {
+        switch ($toggle->getStrategy()) {
+            case Toggle::STRATEGY_AFFIRMATIVE:
+                return 'affirmative';
+            case Toggle::STRATEGY_UNANIMOUS:
+                return 'unanimous';
+            case Toggle::STRATEGY_CONSENSUS:
+                return 'consensus';
+        }
+    }
+
+    private function deserializeStrategy($strategy)
+    {
+        switch ($strategy) {
+            case 'affirmative':
+                return Toggle::STRATEGY_AFFIRMATIVE;
+            case 'unanimous':
+                return Toggle::STRATEGY_UNANIMOUS;
+            case 'consensus':
+                return Toggle::STRATEGY_CONSENSUS;
+        }
+
+        throw new RuntimeException(sprintf('Unknown toggle strategy "%s".', $strategy));
     }
 
     private function assertHasKey($key, array $data)

--- a/lib/Qandidate/Toggle/Toggle.php
+++ b/lib/Qandidate/Toggle/Toggle.php
@@ -28,6 +28,10 @@ class Toggle
     const INACTIVE             = 4;
 
     private $name;
+
+    /**
+     * @var Condition[]
+     */
     private $conditions;
     private $status = self::CONDITIONALLY_ACTIVE;
 

--- a/test/Qandidate/Toggle/Serializer/ToggleSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/ToggleSerializerTest.php
@@ -75,6 +75,33 @@ class ToggleSerializerTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_deserializes_a_toggle_with_strategy()
+    {
+        $serializer = $this->createToggleSerializer();
+
+        $toggle = array(
+            'name' => 'some-feature',
+            'conditions' => array(
+                array(
+                    'name' => 'operator-condition',
+                    'key' => 'user_id',
+                    'operator' => array('name' => 'greater-than', 'value' => 42),
+                ),
+            ),
+            'strategy' => 'unanimous'
+        );
+
+        $operator = new OperatorCondition('user_id', new GreaterThan(42));
+        $expected = new Toggle('some-feature', array($operator), Toggle::STRATEGY_UNANIMOUS);
+
+        $toggle = $serializer->deserialize($toggle);
+
+        $this->assertEquals($expected, $toggle);
+    }
+
+    /**
+     * @test
      * @expectedException RuntimeException
      */
     public function it_throws_exception_on_unsupport_condition()
@@ -97,6 +124,24 @@ class ToggleSerializerTest extends TestCase
 
         $serializer->deserialize($serialized);
     }
+
+
+    /**
+     * @test
+     * @expectedException RuntimeException
+     */
+    public function it_throws_exception_on_unsupported_strategy()
+    {
+        $serializer = $this->createToggleSerializer();
+
+        $serializer->deserialize(array(
+            'name'       => 'some-feature',
+            'conditions' => array(),
+            'status'     => 'inactive',
+            'strategy'   => '',
+        ));
+    }
+
 
     public function missingKeys()
     {

--- a/test/Qandidate/Toggle/Serializer/ToggleSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/ToggleSerializerTest.php
@@ -42,6 +42,7 @@ class ToggleSerializerTest extends TestCase
                     ),
                 ),
                 'status' => 'conditionally-active',
+                'strategy' => 'affirmative',
             ),
             $data
         );

--- a/test/Qandidate/Toggle/ToggleTest.php
+++ b/test/Qandidate/Toggle/ToggleTest.php
@@ -55,6 +55,98 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
+    public function it_is_inactive_if_one_of_the_conditions_holds_with_unanimous_strategy()
+    {
+        $conditions = array(
+            new OperatorCondition('age', new LessThan(42)),
+            new OperatorCondition('age', new GreaterThan(42)),
+        );
+
+        $context   = new Context();
+        $context->set('age', 84);
+
+        $toggle = new Toggle('some-feature', $conditions, Toggle::STRATEGY_UNANIMOUS);
+
+        $this->assertFalse($toggle->activeFor($context));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_active_if_all_of_the_conditions_holds_with_unanimous_strategy()
+    {
+        $conditions = array(
+            new OperatorCondition('age', new GreaterThan(63)),
+            new OperatorCondition('age', new GreaterThan(42)),
+        );
+
+        $context   = new Context();
+        $context->set('age', 84);
+
+        $toggle = new Toggle('some-feature', $conditions, Toggle::STRATEGY_UNANIMOUS);
+
+        $this->assertTrue($toggle->activeFor($context));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_inactive_if_the_conditions_that_hold_equal_half_with_consensus_strategy()
+    {
+        $conditions = array(
+            new OperatorCondition('age', new LessThan(42)),
+            new OperatorCondition('age', new GreaterThan(42)),
+        );
+
+        $context   = new Context();
+        $context->set('age', 84);
+
+        $toggle = new Toggle('some-feature', $conditions, Toggle::STRATEGY_CONSENSUS);
+
+        $this->assertFalse($toggle->activeFor($context));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_inactive_if_least_of_the_conditions_holds_with_consensus_strategy()
+    {
+        $conditions = array(
+            new OperatorCondition('age', new LessThan(42)),
+            new OperatorCondition('age', new LessThan(63)),
+            new OperatorCondition('age', new GreaterThan(42)),
+        );
+
+        $context   = new Context();
+        $context->set('age', 84);
+
+        $toggle = new Toggle('some-feature', $conditions, Toggle::STRATEGY_CONSENSUS);
+
+        $this->assertFalse($toggle->activeFor($context));
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_active_if_most_of_the_conditions_holds_with_consensus_strategy()
+    {
+        $conditions = array(
+            new OperatorCondition('age', new LessThan(42)),
+            new OperatorCondition('age', new GreaterThan(42)),
+            new OperatorCondition('age', new GreaterThan(63)),
+        );
+
+        $context   = new Context();
+        $context->set('age', 84);
+
+        $toggle = new Toggle('some-feature', $conditions, Toggle::STRATEGY_CONSENSUS);
+
+        $this->assertTrue($toggle->activeFor($context));
+    }
+
+    /**
+     * @test
+     */
     public function it_exposes_its_name()
     {
         $toggle = new Toggle('some-feature', array());
@@ -77,6 +169,26 @@ class ToggleTest extends TestCase
         $this->assertCount(2, $actual);
         $this->assertEquals($condition, $actual[0]);
         $this->assertEquals($condition2, $actual[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_exposes_its_strategy()
+    {
+        $toggle = new Toggle('some-feature', array(), Toggle::STRATEGY_UNANIMOUS);
+
+        $this->assertEquals(Toggle::STRATEGY_UNANIMOUS, $toggle->getStrategy());
+    }
+
+    /**
+     * @test
+     */
+    public function its_strategy_is_affirmative_by_default()
+    {
+        $toggle = new Toggle('some-feature', array());
+
+        $this->assertEquals(Toggle::STRATEGY_AFFIRMATIVE, $toggle->getStrategy());
     }
 
     /**
@@ -122,6 +234,16 @@ class ToggleTest extends TestCase
         $toggle = new Toggle('some-feature', array());
 
         $toggle->activate(Toggle::INACTIVE);
+    }
+
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function it_cannot_be_initialized_with_unknown_strategy()
+    {
+        // It tries to inject an active-status because it should never match a strategy
+        new Toggle('some-feature', array(), Toggle::ALWAYS_ACTIVE);
     }
 
     /**


### PR DESCRIPTION
This PR will implement #12, but is a different implementation from #13 

The main difference is I made the strategy part of the Toggle, not part of the activate function. The reasoning is that the strategy is bound to the conditions IMO, not to the "activity" of the toggle. Since Conditions are injected, I think the strategy should also be injected.

Other minor differences:
- I implemented consensus to fail at half
- There is no overlap between active and strategy values
- Strategy is only added to the serialization if not affirmative