### PR TITLE
Fix: Send builds to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 services:
   - redis-server
 


### PR DESCRIPTION
This PR

* [x] explicitly sends builds to container-based infrastructure

See http://docs.travis-ci.com/user/workers/container-based-infrastructure/.