### PR TITLE
Fix: Install dependencies in install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 5.4
   - 5.5
 
-before_script: composer install --dev
+install:
+  - composer install --dev
 
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ php:
   - 5.5
 
 install:
-  - composer install --dev
+  - composer install
 
 script: phpunit


### PR DESCRIPTION
This PR

* [x] installs dependencies in the `install` section
* [x] removes the `--dev` flag, as development dependencies are installed by default

See https://getcomposer.org/doc/03-cli.md#install.