### PR TITLE
Various doc fixes enhancing IDE experience, fixed wrong class name

### DIFF
--- a/lib/Qandidate/Toggle/Condition.php
+++ b/lib/Qandidate/Toggle/Condition.php
@@ -19,7 +19,7 @@ abstract class Condition
     /**
      * @param Context $context
      *
-     * @return boolean True, if the condition holds for the given context
+     * @return bool True, if the condition holds for the given context
      */
     abstract public function holdsFor(Context $context);
 }

--- a/lib/Qandidate/Toggle/Context.php
+++ b/lib/Qandidate/Toggle/Context.php
@@ -17,13 +17,25 @@ namespace Qandidate\Toggle;
  */
 class Context
 {
+    /** @var array */
     private $values = array();
 
+    /**
+     * @param int|string $key
+     *
+     * @return mixed
+     */
     public function get($key)
     {
         return $this->values[$key];
     }
 
+    /**
+     * @param int|string $key
+     * @param mixed      $value
+     *
+     * @return $this
+     */
     public function set($key, $value)
     {
         $this->values[$key] = $value;
@@ -31,11 +43,19 @@ class Context
         return $this;
     }
 
+    /**
+     * @param int|string $key
+     *
+     * @return bool
+     */
     public function has($key)
     {
         return array_key_exists($key, $this->values);
     }
 
+    /**
+     * @return array|mixed[]
+     */
     public function toArray()
     {
         return $this->values;

--- a/lib/Qandidate/Toggle/Operator.php
+++ b/lib/Qandidate/Toggle/Operator.php
@@ -19,7 +19,7 @@ abstract class Operator
     /**
      * @param mixed $argument
      *
-     * @return boolean True, if the operator applies to the argument
+     * @return bool True, if the operator applies to the argument
      */
     abstract public function appliesTo($argument);
 }

--- a/lib/Qandidate/Toggle/Operator/EqualTo.php
+++ b/lib/Qandidate/Toggle/Operator/EqualTo.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the qandidate/toggle package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Qandidate\Toggle\Operator;
 
 class EqualTo extends EqualityOperator

--- a/lib/Qandidate/Toggle/Operator/MatchesRegex.php
+++ b/lib/Qandidate/Toggle/Operator/MatchesRegex.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the qandidate/toggle package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Qandidate\Toggle\Operator;
 
 class MatchesRegex extends EqualityOperator

--- a/lib/Qandidate/Toggle/OperatorCondition.php
+++ b/lib/Qandidate/Toggle/OperatorCondition.php
@@ -16,7 +16,10 @@ namespace Qandidate\Toggle;
  */
 class OperatorCondition extends Condition
 {
+    /** @var string */
     private $key;
+
+    /** @var Operator */
     private $operator;
 
     /**
@@ -28,6 +31,7 @@ class OperatorCondition extends Condition
         $this->key      = $key;
         $this->operator = $operator;
     }
+
     /**
      * {@inheritdoc}
      */

--- a/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
@@ -12,7 +12,7 @@
 namespace Qandidate\Toggle\Serializer;
 
 use Qandidate\Toggle\Operator;
-use Qandidate\Toggle\Operator\EqualsTo;
+use Qandidate\Toggle\Operator\EqualTo;
 use Qandidate\Toggle\Operator\GreaterThan;
 use Qandidate\Toggle\Operator\GreaterThanEqual;
 use Qandidate\Toggle\Operator\InSet;
@@ -35,8 +35,8 @@ class OperatorSerializer
     public function serialize(Operator $operator)
     {
         switch(true) {
-            case $operator instanceof EqualsTo:
-                return array('name' => 'equals-to', 'value' => $operator->getValue());
+            case $operator instanceof EqualTo:
+                return array('name' => 'equal-to', 'value' => $operator->getValue());
             case $operator instanceof GreaterThan:
                 return array('name' => 'greater-than', 'value' => $operator->getValue());
             case $operator instanceof GreaterThanEqual:
@@ -66,10 +66,11 @@ class OperatorSerializer
         $this->assertHasKey('name', $operator);
 
         switch($operator['name']) {
-            case 'equals-to':
+            case 'equals-to': // Left for backward compatibility, todo: should be removed in future
+            case 'equal-to':
                 $this->assertHasKey('value', $operator);
 
-                return new EqualsTo($operator['value']);
+                return new EqualTo($operator['value']);
             case 'greater-than':
                 $this->assertHasKey('value', $operator);
 

--- a/lib/Qandidate/Toggle/Toggle.php
+++ b/lib/Qandidate/Toggle/Toggle.php
@@ -27,15 +27,32 @@ class Toggle
     const ALWAYS_ACTIVE        = 2;
     const INACTIVE             = 4;
 
+    /** At least one of the provided conditions has to be met */
     const STRATEGY_AFFIRMATIVE = 1;
+
+    /** At least half of the provided conditions have to be met */
     const STRATEGY_MAJORITY    = 2;
+
+    /** All conditions have to be met */
     const STRATEGY_UNANIMOUS   = 3;
 
+    /** @var string */
     private $name;
+
+    /** @var array|Condition[] */
     private $conditions;
+
+    /** @var int */
     private $status = self::CONDITIONALLY_ACTIVE;
+
+    /** @var int */
     private $strategy = self::STRATEGY_AFFIRMATIVE;
 
+    /**
+     * @param                   $name
+     * @param array|Condition[] $conditions
+     * @param int               $strategy
+     */
     public function __construct($name, array $conditions, $strategy = self::STRATEGY_AFFIRMATIVE)
     {
         $this->name       = $name;
@@ -45,7 +62,7 @@ class Toggle
     }
 
     /**
-     * @param integer $status
+     * @param int $status
      */
     public function activate($status = self::CONDITIONALLY_ACTIVE)
     {
@@ -58,7 +75,7 @@ class Toggle
      *
      * @param Context $context
      *
-     * @return boolean True, if one of conditions hold for the context.
+     * @return bool True, if one of conditions hold for the context.
      */
     public function activeFor(Context $context)
     {
@@ -79,13 +96,18 @@ class Toggle
         }
     }
 
+    /**
+     * Immediately set this toggle's status to inactive
+     *
+     * @return int The status code after deactivation
+     */
     public function deactivate()
     {
         return $this->status = self::INACTIVE;
     }
 
     /**
-     * @return array
+     * @return array|Condition[]
      */
     public function getConditions()
     {
@@ -109,7 +131,7 @@ class Toggle
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getStatus()
     {
@@ -117,7 +139,7 @@ class Toggle
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getStrategy()
     {
@@ -125,7 +147,7 @@ class Toggle
     }
 
     /**
-     * @param $status
+     * @param int $status
      */
     private function assertValidActiveStatus($status)
     {
@@ -135,7 +157,7 @@ class Toggle
     }
 
     /**
-     * @param $strategy
+     * @param int $strategy
      */
     private function assertValidStrategy($strategy)
     {

--- a/lib/Qandidate/Toggle/ToggleCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection.php
@@ -20,7 +20,7 @@ namespace Qandidate\Toggle;
 abstract class ToggleCollection
 {
     /**
-     * @return array
+     * @return array|Toggle[]
      */
     abstract public function all();
 
@@ -40,7 +40,7 @@ abstract class ToggleCollection
     /**
      * @param string $name
      *
-     * @return boolean True, if element was removed
+     * @return bool True, if element was removed
      */
     abstract public function remove($name);
 }

--- a/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
@@ -20,6 +20,7 @@ use Qandidate\Toggle\ToggleCollection;
  */
 class InMemoryCollection extends ToggleCollection
 {
+    /** @var array|Toggle[] */
     private $toggles = array();
 
     /**
@@ -35,7 +36,7 @@ class InMemoryCollection extends ToggleCollection
      */
     public function get($name)
     {
-        if ( ! array_key_exists($name, $this->toggles)) {
+        if (!array_key_exists($name, $this->toggles)) {
             return null;
         }
 
@@ -55,7 +56,7 @@ class InMemoryCollection extends ToggleCollection
      */
     public function remove($name)
     {
-        if ( ! array_key_exists($name, $this->toggles)) {
+        if (!array_key_exists($name, $this->toggles)) {
             return false;
         }
 

--- a/lib/Qandidate/Toggle/ToggleManager.php
+++ b/lib/Qandidate/Toggle/ToggleManager.php
@@ -32,7 +32,7 @@ class ToggleManager
      * @param string  $name
      * @param Context $context
      *
-     * @return True, if the toggle exists and is active
+     * @return bool True, if the toggle exists and is active
      */
     public function active($name, Context $context)
     {
@@ -48,7 +48,7 @@ class ToggleManager
      *
      * @param string $name
      *
-     * @return boolean True, if element was removed
+     * @return bool True, if element was removed
      */
     public function remove($name)
     {
@@ -114,7 +114,7 @@ class ToggleManager
         if (false === $this->add($currentToggle)) {
             throw new RuntimeException(
                 sprintf(
-                    'Failed to rename toggle %1$s to %2$s, an error occured when saving toggle with new name',
+                    'Failed to rename toggle %1$s to %2$s, an error occurred when saving toggle with new name',
                     $oldName,
                     $newName
                 )
@@ -125,7 +125,7 @@ class ToggleManager
     }
 
     /**
-     * @return array All toggles from the manager.
+     * @return array|Toggle[] All toggles from the manager.
      */
     public function all()
     {


### PR DESCRIPTION
- Added PHPDoc typehints powering up IDE auto-completion
- Fixed reference to undefined class `EqualsTo` - replaced it with `EqualTo`
- Unified `bool` / `int` typehints
- Fixed spotted typo