### PR TITLE
Skip redis tests if there is no redis connection

### DIFF
--- a/test/Qandidate/Toggle/ToggleCollection/PredisCollectionTest.php
+++ b/test/Qandidate/Toggle/ToggleCollection/PredisCollectionTest.php
@@ -12,6 +12,7 @@
 namespace Qandidate\Toggle\ToggleCollection;
 
 use Predis\Client;
+use Predis\Connection\ConnectionException;
 use Qandidate\Toggle\ToggleCollectionTest;
 
 class PredisCollectionTest extends ToggleCollectionTest
@@ -23,6 +24,11 @@ class PredisCollectionTest extends ToggleCollectionTest
     {
         $this->client     = new Client();
         $this->collection = new PredisCollection('toggle_predis_test', $this->client);
+        try {
+            $this->client->connect();
+        } catch (ConnectionException $e) {
+            $this->markTestSkipped('Failed to connect to redis.');
+        }
     }
 
     public function tearDown()


### PR DESCRIPTION
When running the unit tests locally not everyone might have a working
redis installation to test against. In that case mark the tests as
skipped instead of spewing a bunch of errors to the console.

```
$ phpunit
...
OK, but incomplete, skipped, or risky tests!
Tests: 209, Assertions: 229, Skipped: 7.
```