### PR TITLE
Don't require an associative array for serialized toggles.

### DIFF
--- a/lib/Qandidate/Toggle/Serializer/InMemoryCollectionSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/InMemoryCollectionSerializer.php
@@ -15,8 +15,9 @@ class InMemoryCollectionSerializer
         $collection = new InMemoryCollection();
         $serializer = new ToggleSerializer(new OperatorConditionSerializer(new OperatorSerializer()));
 
-        foreach ($data as $name => $serializedToggle) {
+        foreach ($data as $serializedToggle) {
             $toggle = $serializer->deserialize($serializedToggle);
+            $name = $toggle->getName();
             $collection->set($name, $toggle);
         }
 
@@ -31,8 +32,8 @@ class InMemoryCollectionSerializer
     {
         $serializer = new ToggleSerializer(new OperatorConditionSerializer(new OperatorSerializer()));
         $ret = array();
-        foreach ($toggleCollection->all() as $key => $toggle) {
-            $ret[$key] = $serializer->serialize($toggle);
+        foreach ($toggleCollection->all() as $toggle) {
+            $ret[] = $serializer->serialize($toggle);
         }
 
         return $ret;

--- a/test/Qandidate/Toggle/Serializer/InMemoryCollectionSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/InMemoryCollectionSerializerTest.php
@@ -16,7 +16,7 @@ class InMemoryCollectionSerializerTest extends TestCase
     public function it_unserializes_a_collection_from_an_array()
     {
         $data = array(
-            'some-feature' => array(
+            array(
                 'name' => 'toggling',
                 'conditions' => array(
                     array(
@@ -32,7 +32,7 @@ class InMemoryCollectionSerializerTest extends TestCase
         $serializer = new InMemoryCollectionSerializer();
         $collection = $serializer->deserialize($data);
 
-        $this->assertInstanceOf('Qandidate\Toggle\Toggle', $collection->get('some-feature'));
+        $this->assertInstanceOf('Qandidate\Toggle\Toggle', $collection->get('toggling'));
         $this->assertCount(1, $collection->all());
     }
 
@@ -51,10 +51,10 @@ class InMemoryCollectionSerializerTest extends TestCase
         $serialized = $serializer->serialize($collection);
 
         $this->assertInternalType('array', $serialized);
-        $this->assertArrayHasKey('some-feature', $serialized);
-        $this->assertArrayHasKey('name', $serialized['some-feature']);
-        $this->assertArrayHasKey('conditions', $serialized['some-feature']);
-        $this->assertSame('toggling', $serialized['some-feature']['name']);
+        $this->assertCount(1, $serialized);
+        $this->assertArrayHasKey('name', $serialized[0]);
+        $this->assertArrayHasKey('conditions', $serialized[0]);
+        $this->assertSame('toggling', $serialized[0]['name']);
     }
 
     /**
@@ -66,7 +66,7 @@ class InMemoryCollectionSerializerTest extends TestCase
         $operator   = new LessThan(42);
         $condition  = new OperatorCondition('user_id', $operator);
         $toggle     = new Toggle('toggling', array($condition));
-        $collection->set('some-feature', $toggle);
+        $collection->set('toggling', $toggle);
         $serializer = new InMemoryCollectionSerializer();
 
         $serialized = $serializer->serialize($collection);


### PR DESCRIPTION
As discussed in #27 the (de)serialization of toggles shouldn't use an associative array as it can cause confusion when defining your toggles in an array or yml/json/... file. This PR does away with the keys altogether, both in serialization and deserialization. Alternatively, we could keep serializing them to an associative array, and check whether the key is an int or a string during deserialization (and use the "internal" name if the key is an int). However I felt this would make the process overly complex, but if that's the preferred solution I could change it to do that, as it would guarantee backwards compatibility. With the current approach, it's only backwards compatible if the toggle's name is the same both as the key and as the "internal" name.