### PR TITLE
Lock PHPUnit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 services:
   - redis-server
 
@@ -9,9 +13,10 @@ matrix:
   include:
     - php: 5.5
     - php: 5.6
-    - php: 7
+    - php: 7.0
+    - php: 7.1
 
 install:
   - composer install
 
-script: phpunit
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": ">=5.5.9"
     },
     "require-dev": {
+        "phpunit/phpunit": "~4.8",
         "predis/predis": "~0.8",
         "symfony/expression-language": "~2.4"
     },


### PR DESCRIPTION
Last Travis run failed on PHP 7.0 as it has a different PHPUnit version, this hopefully fixes it. This adds it as a dev dependency (alternative is to fetch a PHAR and cache it).