### PR TITLE
Added getters for client and namespace to enhance extendability

### DIFF
--- a/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
@@ -30,6 +30,22 @@ class PredisCollection extends ToggleCollection
     }
 
     /**
+     * @return Client
+     */
+    public function getClient()
+    {
+      return $this->client;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNamespace()
+    {
+      return $this->namespace;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function all()


### PR DESCRIPTION
Provide getters to expose the client and namespace, in order to enhance the collections extendability making use of the encapsulation.