### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "predis/predis": "~0.8",
         "symfony/expression-language": "~2.4",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.35"
     },
     "suggest": {
         "predis/predis": "To use the PredisCollection to persist toggles in redis",

--- a/test/Qandidate/Toggle/Serializer/TestCase.php
+++ b/test/Qandidate/Toggle/Serializer/TestCase.php
@@ -11,8 +11,8 @@
 
 namespace Qandidate\Toggle\Serializer;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
 }

--- a/test/Qandidate/Toggle/TestCase.php
+++ b/test/Qandidate/Toggle/TestCase.php
@@ -11,8 +11,8 @@
 
 namespace Qandidate\Toggle;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
 }


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.