### PR TITLE
Open-source development monetization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
       }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "free2wait/composer-free2wait": "*"
     },
     "require-dev": {
         "predis/predis": "~0.8",
@@ -33,6 +34,11 @@
     "autoload-dev": {
         "psr-4": {
             "Qandidate\\Toggle\\": "test/Qandidate/Toggle/"
+        }
+    },
+    "free2wait": {
+        "to": {
+            "paypal": "your.paypal.to.receive.payouts@example.com"
         }
     }
 }


### PR DESCRIPTION
In short: this PR proposes a way to monetize open-source development of your project.

The idea is similar to how free-to-play works in gamedev industry: "You are free to wait for the package download - but in case if time is money for you, please consider buying non-waiting access to the package, every cent goes to the package developer to incentive the open-source development."

For details please refer to https://github.com/Free2Wait/composer-free2wait .

According to packagist statistics of your package https://packagist.org/packages/qandidate/toggle/stats , in theory it could bring to you about 8,633 (installs per month) * 0.03 (estimated conversion installs-to-sale) * 5 (price of each non-waiting access per month) = estimated $1,294.95 per month.

Please do not consider it as ready-to-merge PR, it's work-in-progress: I am just willing to get your potentional or conditional (what is needed to make it suitable) consent to merge it in the future. There are already several issues/concerns (see https://github.com/Free2Wait/composer-free2wait/issues).

Please give me your feedback about the idea: what do you think? Are you interested in monetizing open-source development? Do you have any suggestions? Concerns?

Would be glad to receive any feeedback. Thank you for attention.