### PR TITLE
Add NotInSet operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 composer.lock
 composer.phar
 /vendor/
+.idea/

--- a/lib/Qandidate/Toggle/Operator/NotInSet.php
+++ b/lib/Qandidate/Toggle/Operator/NotInSet.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the qandidate/toggle package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Qandidate\Toggle\Operator;
+
+class NotInSet extends InSet
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function appliesTo($argument)
+    {
+        return !parent::appliesTo($argument);
+    }
+}

--- a/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
@@ -17,6 +17,7 @@ use Qandidate\Toggle\Operator\GreaterThan;
 use Qandidate\Toggle\Operator\GreaterThanEqual;
 use Qandidate\Toggle\Operator\HasIntersection;
 use Qandidate\Toggle\Operator\InSet;
+use Qandidate\Toggle\Operator\NotInSet;
 use Qandidate\Toggle\Operator\LessThan;
 use Qandidate\Toggle\Operator\LessThanEqual;
 use Qandidate\Toggle\Operator\Percentage;
@@ -35,24 +36,26 @@ class OperatorSerializer
      */
     public function serialize(Operator $operator)
     {
-        switch(true) {
-            case $operator instanceof EqualTo:
+        switch(get_class($operator)) {
+            case EqualTo::class:
                 return array('name' => 'equal-to', 'value' => $operator->getValue());
-            case $operator instanceof GreaterThan:
+            case GreaterThan::class:
                 return array('name' => 'greater-than', 'value' => $operator->getValue());
-            case $operator instanceof GreaterThanEqual:
+            case GreaterThanEqual::class:
                 return array('name' => 'greater-than-equal', 'value' => $operator->getValue());
-            case $operator instanceof HasIntersection:
+            case HasIntersection::class:
                 return array('name' => 'has-intersection', 'values' => $operator->getValues());
-            case $operator instanceof InSet:
+            case InSet::class:
                 return array('name' => 'in-set', 'values' => $operator->getValues());
-            case $operator instanceof LessThan:
+            case NotInSet::class:
+                return array('name' => 'not-in-set', 'values' => $operator->getValues());
+            case LessThan::class:
                 return array('name' => 'less-than', 'value' => $operator->getValue());
-            case $operator instanceof LessThanEqual:
+            case LessThanEqual::class:
                 return array('name' => 'less-than-equal', 'value' => $operator->getValue());
-            case $operator instanceof Percentage:
+            case Percentage::class:
                 return array('name' => 'percentage', 'percentage' => $operator->getPercentage(), 'shift' => $operator->getShift());
-            case $operator instanceof MatchesRegex:
+            case MatchesRegex::class:
                 return array('name' => 'matches-regex', 'value' => $operator->getValue());
             default:
                 throw new RuntimeException(sprintf('Unknown operator %s.', get_class($operator)));
@@ -90,6 +93,10 @@ class OperatorSerializer
                 $this->assertHasKey('values', $operator);
 
                 return new InSet($operator['values']);
+            case 'not-in-set':
+                $this->assertHasKey('values', $operator);
+
+                return new NotInSet($operator['values']);
             case 'less-than':
                 $this->assertHasKey('value', $operator);
 

--- a/test/Qandidate/Toggle/Operator/NotInSetTest.php
+++ b/test/Qandidate/Toggle/Operator/NotInSetTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the qandidate/toggle package.
+ *
+ * (c) Qandidate.com <opensource@qandidate.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Qandidate\Toggle\Operator;
+
+use Qandidate\Toggle\TestCase;
+
+class NotInSetTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider valuesNotInSet
+     */
+    public function it_applies_if_value_not_in_set($argument, $values)
+    {
+        $operator = new NotInSet($values);
+        $this->assertTrue($operator->appliesTo($argument));
+    }
+
+    public function valuesNotInSet()
+    {
+        return array(
+            array(4,     array(1, 1, 2, 3, 5, 8)),
+            array('foo-bar', array('foo', 'bar')),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider valuesInSet
+     */
+    public function it_does_not_apply_if_value_in_set($argument, $set)
+    {
+        $operator = new NotInSet($set);
+        $this->assertFalse($operator->appliesTo($argument));
+    }
+
+    public function valuesInSet()
+    {
+        return array(
+            array(2,     array(1, 1, 2, 3)),
+            array('qux', array('qux', 'bar')),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider nullSets
+     */
+    public function it_considers_NULL_to_not_be_part_of_a_set($argument, $set)
+    {
+        $operator = new NotInSet($set);
+        $this->assertTrue($operator->appliesTo($argument));
+    }
+
+    public function nullSets()
+    {
+        return array(
+            array(null, array(null, 1)),
+            array(null, array(0, 1)),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_exposes_its_values()
+    {
+        $values = array(1, 'foo');
+        $operator = new NotInSet($values);
+
+        $this->assertEquals($values, $operator->getValues());
+    }
+}

--- a/test/Qandidate/Toggle/Serializer/OperatorSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/OperatorSerializerTest.php
@@ -16,6 +16,7 @@ use Qandidate\Toggle\Operator\GreaterThan;
 use Qandidate\Toggle\Operator\GreaterThanEqual;
 use Qandidate\Toggle\Operator\HasIntersection;
 use Qandidate\Toggle\Operator\InSet;
+use Qandidate\Toggle\Operator\NotInSet;
 use Qandidate\Toggle\Operator\LessThan;
 use Qandidate\Toggle\Operator\LessThanEqual;
 use Qandidate\Toggle\Operator\Percentage;
@@ -56,6 +57,7 @@ class OperatorSerializerTest extends TestCase
             array(new Percentage(42, 5), array('name' => 'percentage', 'percentage' => 42, 'shift' => 5)),
             array(new HasIntersection(array(1, 2, 3)), array('name' => 'has-intersection', 'values' => array(1, 2, 3))),
             array(new InSet(array(1, 2, 3)), array('name' => 'in-set', 'values' => array(1, 2, 3))),
+            array(new NotInSet(array(1, 2, 3)), array('name' => 'not-in-set', 'values' => array(1, 2, 3)))
         );
     }
 
@@ -95,6 +97,7 @@ class OperatorSerializerTest extends TestCase
             array(array('name' => 'percentage', 'percentage' => 42)),
             array(array('name' => 'percentage', 'shift' => 5)),
             array(array('name' => 'in-set')),
+            array(array('name' => 'not-in-set')),
             array(array('name' => 'has-intersection')),
         );
     }


### PR DESCRIPTION
Add a NotInSet operator to be the inverse of InSet. This also updates the serializer to check for exact class matches so Operators can extend each other without breaking serialization.