### PR TITLE
Enhancement: Add PHP 7.1 and 7.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ matrix:
   include:
     - php: 5.5
     - php: 5.6
-    - php: 7
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
 
 install:
   - composer install


### PR DESCRIPTION
This PR

* [x] adds PHP 7.1 and 7.2 to the Travis build matrix