### PR TITLE
Fix example in from-array.php

### DIFF
--- a/examples/from-array.php
+++ b/examples/from-array.php
@@ -29,9 +29,9 @@ $manager    = new ToggleManager($collection);
 // Create and check a new context for a user with id 42
 $context = new Context();
 $context->set('user_id', 42);
-var_dump($manager->active('some-feature', $context)); // true
+var_dump($manager->active('toggling', $context)); // true
 
 // Create and check a new context for a user with id 21
 $context = new Context();
 $context->set('user_id', 21);
-var_dump($manager->active('some-feature', $context)); // false
+var_dump($manager->active('toggling', $context)); // false


### PR DESCRIPTION
Hi there! It seems that your `examples/from-array.php` not working as expected.

Please check it and merge it if that is correct behaviour of `InMemoryCollectionSerializer`.

If `InMemoryCollectionSerializer` is broken for example, please let me know, maybe it would better to fix it.

Proofs (difference see in changed file):

**It was:**
![image](https://user-images.githubusercontent.com/20535375/61650257-eefe0f00-acbb-11e9-8589-5c7ce116ff08.png)

**It now:**
![image](https://user-images.githubusercontent.com/20535375/61650281-00471b80-acbc-11e9-95c8-d70e39729857.png)

P.S. I check other examples and they work like a charm