### PR TITLE
create PR for CS fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,16 @@ jobs:
         uses: "ramsey/composer-install@v1"
       - name: "Check coding standards"
         run: "make php-cs-fixer-ci"
+      - name: Create Pull Request
+        if: github.ref == 'refs/heads/master'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Apply coding standards
+          branch: php-cs-fixer
+          delete-branch: true
+          title: 'Apply coding standards'
+          draft: false
+          base: master
 
   static-analysis:
     name: "Static analysis"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ php-cs-fixer:
 
 .PHONY: php-cs-fixer-ci
 php-cs-fixer-ci:
-	vendor/bin/php-cs-fixer fix --dry-run --no-interaction --allow-risky=yes --diff --verbose
+	vendor/bin/php-cs-fixer fix --no-interaction --allow-risky=yes --diff --verbose
 
 PHONY: phpstan
 phpstan:


### PR DESCRIPTION
because I don't want to manually fix a failing CI because of a newer version of php-cs-fixer, see https://github.com/qandidate-labs/qandidate-toggle/actions/runs/2650066627