### PR TITLE
Welcome to 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,13 @@ on:
 jobs:
   tests:
     name: "Run tests"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -40,14 +39,14 @@ jobs:
 
   coding-standards:
     name: "Coding standards"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.0"
+          php-version: "8.3"
           coverage: "none"
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
@@ -66,14 +65,14 @@ jobs:
 
   static-analysis:
     name: "Static analysis"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.0"
+          php-version: "8.3"
           coverage: "none"
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ php-cs-fixer-ci:
 PHONY: phpstan
 phpstan:
 	vendor/bin/phpstan analyse --level=max lib/
+	vendor/bin/phpstan analyse --level=max test/
 
 .PHONY: changelog
 changelog:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/expression-language": "^3.4||^4.4||^5.0",
         "phpunit/phpunit": "^9.5",
         "broadway/coding-standard": "^1.2",
-        "phpstan/phpstan": "@stable"
+        "phpstan/phpstan": "@stable",
+        "rector/rector": "1.0.2"
     },
     "suggest": {
         "predis/predis": "To use the PredisCollection to persist toggles in redis",

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
       }
     ],
     "require": {
-        "php": ">=7.2"
+        "php": ">=8.1"
     },
     "require-dev": {
         "predis/predis": "^1.1||^2.0",
         "symfony/expression-language": "^3.4||^4.4||^5.0",
         "phpunit/phpunit": "^9.5",
         "broadway/coding-standard": "^1.2",
-        "phpstan/phpstan": "@stable",
+        "phpstan/phpstan": "^1.10",
         "rector/rector": "1.0.2"
     },
     "suggest": {

--- a/lib/Qandidate/Toggle/Condition.php
+++ b/lib/Qandidate/Toggle/Condition.php
@@ -16,10 +16,10 @@ namespace Qandidate\Toggle;
 /**
  * For a condition it can be checked if it holds for a given context.
  */
-abstract class Condition
+interface Condition
 {
     /**
      * @return bool True, if the condition holds for the given context
      */
-    abstract public function holdsFor(Context $context): bool;
+    public function holdsFor(Context $context): bool;
 }

--- a/lib/Qandidate/Toggle/Context.php
+++ b/lib/Qandidate/Toggle/Context.php
@@ -19,10 +19,7 @@ namespace Qandidate\Toggle;
  */
 class Context
 {
-    /**
-     * @var array
-     */
-    private $values = [];
+    private array $values = [];
 
     /**
      * @param int|string $key
@@ -37,7 +34,7 @@ class Context
      *
      * @return $this
      */
-    public function set($key, $value)
+    public function set($key, $value): static
     {
         $this->values[$key] = $value;
 

--- a/lib/Qandidate/Toggle/Context.php
+++ b/lib/Qandidate/Toggle/Context.php
@@ -21,30 +21,19 @@ class Context
 {
     private array $values = [];
 
-    /**
-     * @param int|string $key
-     */
-    public function get($key)
+    public function get(int|string $key): mixed
     {
         return $this->values[$key];
     }
 
-    /**
-     * @param int|string $key
-     *
-     * @return $this
-     */
-    public function set($key, $value): static
+    public function set(int|string $key, mixed $value): static
     {
         $this->values[$key] = $value;
 
         return $this;
     }
 
-    /**
-     * @param int|string $key
-     */
-    public function has($key): bool
+    public function has(int|string $key): bool
     {
         return array_key_exists($key, $this->values);
     }

--- a/lib/Qandidate/Toggle/ContextFactory.php
+++ b/lib/Qandidate/Toggle/ContextFactory.php
@@ -28,7 +28,7 @@ namespace Qandidate\Toggle;
  *     $context->set('company_id', $user->getCompanyId());
  *     $context->set('ip', $request->getClientIp());
  */
-abstract class ContextFactory
+interface ContextFactory
 {
-    abstract public function createContext(): Context;
+    public function createContext(): Context;
 }

--- a/lib/Qandidate/Toggle/ExpressionCondition.php
+++ b/lib/Qandidate/Toggle/ExpressionCondition.php
@@ -19,7 +19,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
  * A condition written as a symfony language expression that gets evaluated against the
  * full context, allowing access to several keys of the context in a single condition.
  */
-class ExpressionCondition extends Condition
+class ExpressionCondition implements Condition
 {
     public function __construct(protected string $expression, protected ExpressionLanguage $language)
     {

--- a/lib/Qandidate/Toggle/ExpressionCondition.php
+++ b/lib/Qandidate/Toggle/ExpressionCondition.php
@@ -21,20 +21,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
  */
 class ExpressionCondition extends Condition
 {
-    /**
-     * @var string
-     */
-    protected $expression;
-
-    /**
-     * @var ExpressionLanguage
-     */
-    protected $language;
-
-    public function __construct(string $expression, ExpressionLanguage $language)
+    public function __construct(protected string $expression, protected ExpressionLanguage $language)
     {
-        $this->expression = $expression;
-        $this->language = $language;
     }
 
     public function holdsFor(Context $context): bool

--- a/lib/Qandidate/Toggle/Operator.php
+++ b/lib/Qandidate/Toggle/Operator.php
@@ -25,5 +25,5 @@ interface Operator
      *
      * @return bool returns true if the operator applies to the argument
      */
-    public function appliesTo($argument): bool;
+    public function appliesTo(mixed $argument): bool;
 }

--- a/lib/Qandidate/Toggle/Operator.php
+++ b/lib/Qandidate/Toggle/Operator.php
@@ -15,11 +15,15 @@ namespace Qandidate\Toggle;
 
 /**
  * Operator calculates whether it applies to an argument or not.
+ *
+ * @template T
  */
-abstract class Operator
+interface Operator
 {
     /**
-     * @return bool True, if the operator applies to the argument
+     * @param T $argument
+     *
+     * @return bool returns true if the operator applies to the argument
      */
-    abstract public function appliesTo($argument): bool;
+    public function appliesTo($argument): bool;
 }

--- a/lib/Qandidate/Toggle/Operator/EqualTo.php
+++ b/lib/Qandidate/Toggle/Operator/EqualTo.php
@@ -15,7 +15,7 @@ namespace Qandidate\Toggle\Operator;
 
 class EqualTo extends EqualityOperator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return $argument === $this->value;
     }

--- a/lib/Qandidate/Toggle/Operator/EqualityOperator.php
+++ b/lib/Qandidate/Toggle/Operator/EqualityOperator.php
@@ -20,11 +20,8 @@ use Qandidate\Toggle\Operator;
  */
 abstract class EqualityOperator extends Operator
 {
-    protected $value;
-
-    public function __construct($value)
+    public function __construct(protected $value)
     {
-        $this->value = $value;
     }
 
     /**

--- a/lib/Qandidate/Toggle/Operator/EqualityOperator.php
+++ b/lib/Qandidate/Toggle/Operator/EqualityOperator.php
@@ -16,18 +16,23 @@ namespace Qandidate\Toggle\Operator;
 use Qandidate\Toggle\Operator;
 
 /**
+ * @template T
+ *
  * Operator that compare the given argument on equality based on a value.
  */
-abstract class EqualityOperator extends Operator
+abstract class EqualityOperator implements Operator
 {
+    /**
+     * @param T $value
+     */
     public function __construct(protected $value)
     {
     }
 
     /**
-     * @return mixed The value compared to
+     * @return T The value compared to
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/lib/Qandidate/Toggle/Operator/GreaterThan.php
+++ b/lib/Qandidate/Toggle/Operator/GreaterThan.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+/**
+ * @template T
+ * @template-extends EqualityOperator<T> 
+ */
 class GreaterThan extends EqualityOperator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return $argument > $this->value;
     }

--- a/lib/Qandidate/Toggle/Operator/GreaterThan.php
+++ b/lib/Qandidate/Toggle/Operator/GreaterThan.php
@@ -15,7 +15,8 @@ namespace Qandidate\Toggle\Operator;
 
 /**
  * @template T
- * @template-extends EqualityOperator<T> 
+ *
+ * @template-extends EqualityOperator<T>
  */
 class GreaterThan extends EqualityOperator
 {

--- a/lib/Qandidate/Toggle/Operator/GreaterThanEqual.php
+++ b/lib/Qandidate/Toggle/Operator/GreaterThanEqual.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+/**
+ * @template T
+ * @template-extends EqualityOperator<T> 
+ */
 class GreaterThanEqual extends EqualityOperator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return $argument >= $this->value;
     }

--- a/lib/Qandidate/Toggle/Operator/GreaterThanEqual.php
+++ b/lib/Qandidate/Toggle/Operator/GreaterThanEqual.php
@@ -15,7 +15,8 @@ namespace Qandidate\Toggle\Operator;
 
 /**
  * @template T
- * @template-extends EqualityOperator<T> 
+ *
+ * @template-extends EqualityOperator<T>
  */
 class GreaterThanEqual extends EqualityOperator
 {

--- a/lib/Qandidate/Toggle/Operator/HasIntersection.php
+++ b/lib/Qandidate/Toggle/Operator/HasIntersection.php
@@ -15,14 +15,8 @@ namespace Qandidate\Toggle\Operator;
 
 class HasIntersection extends EqualityOperator
 {
-    /**
-     * @var array
-     */
-    private $values;
-
-    public function __construct(array $values)
+    public function __construct(private readonly array $values)
     {
-        $this->values = $values;
     }
 
     public function appliesTo($argument): bool

--- a/lib/Qandidate/Toggle/Operator/HasIntersection.php
+++ b/lib/Qandidate/Toggle/Operator/HasIntersection.php
@@ -13,11 +13,9 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
-use InvalidArgumentException;
-
-
 /**
  * @template T
+ *
  * @template-extends EqualityOperator<T>
  */
 class HasIntersection extends EqualityOperator
@@ -32,7 +30,7 @@ class HasIntersection extends EqualityOperator
     public function appliesTo(mixed $argument): bool
     {
         if (!is_array($argument)) {
-            throw new InvalidArgumentException('HasIntersection can only be compared against array values');
+            throw new \InvalidArgumentException('HasIntersection can only be compared against array values');
         }
 
         return null !== $argument

--- a/lib/Qandidate/Toggle/Operator/HasIntersection.php
+++ b/lib/Qandidate/Toggle/Operator/HasIntersection.php
@@ -13,14 +13,28 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+use InvalidArgumentException;
+
+
+/**
+ * @template T
+ * @template-extends EqualityOperator<T>
+ */
 class HasIntersection extends EqualityOperator
 {
+    /**
+     * @param array<T> $values
+     */
     public function __construct(private readonly array $values)
     {
     }
 
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
+        if (!is_array($argument)) {
+            throw new InvalidArgumentException('HasIntersection can only be compared against array values');
+        }
+
         return null !== $argument
             && array_intersect($argument, $this->values);
     }

--- a/lib/Qandidate/Toggle/Operator/InSet.php
+++ b/lib/Qandidate/Toggle/Operator/InSet.php
@@ -15,18 +15,30 @@ namespace Qandidate\Toggle\Operator;
 
 use Qandidate\Toggle\Operator;
 
-class InSet extends Operator
+/**
+ * @template T
+ */
+class InSet implements Operator
 {
+    /**
+     * @param array<T> $values
+     */
     public function __construct(private readonly array $values)
     {
     }
 
-    public function appliesTo($argument): bool
+    /**
+     * @param T $argument
+     */
+    public function appliesTo(mixed $argument): bool
     {
         return null !== $argument
             && in_array($argument, $this->values);
     }
 
+    /**
+     * @return array<T>
+     */
     public function getValues(): array
     {
         return $this->values;

--- a/lib/Qandidate/Toggle/Operator/InSet.php
+++ b/lib/Qandidate/Toggle/Operator/InSet.php
@@ -17,14 +17,8 @@ use Qandidate\Toggle\Operator;
 
 class InSet extends Operator
 {
-    /**
-     * @var array
-     */
-    private $values;
-
-    public function __construct(array $values)
+    public function __construct(private readonly array $values)
     {
-        $this->values = $values;
     }
 
     public function appliesTo($argument): bool

--- a/lib/Qandidate/Toggle/Operator/LessThan.php
+++ b/lib/Qandidate/Toggle/Operator/LessThan.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+/**
+ * @template T
+ * @template-extends EqualityOperator<T> 
+ */
 class LessThan extends EqualityOperator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return $argument < $this->value;
     }

--- a/lib/Qandidate/Toggle/Operator/LessThan.php
+++ b/lib/Qandidate/Toggle/Operator/LessThan.php
@@ -15,7 +15,8 @@ namespace Qandidate\Toggle\Operator;
 
 /**
  * @template T
- * @template-extends EqualityOperator<T> 
+ *
+ * @template-extends EqualityOperator<T>
  */
 class LessThan extends EqualityOperator
 {

--- a/lib/Qandidate/Toggle/Operator/LessThanEqual.php
+++ b/lib/Qandidate/Toggle/Operator/LessThanEqual.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+/**
+ * @template T
+ * @template-extends EqualityOperator<T> 
+ */
 class LessThanEqual extends EqualityOperator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return $argument <= $this->value;
     }

--- a/lib/Qandidate/Toggle/Operator/LessThanEqual.php
+++ b/lib/Qandidate/Toggle/Operator/LessThanEqual.php
@@ -15,7 +15,8 @@ namespace Qandidate\Toggle\Operator;
 
 /**
  * @template T
- * @template-extends EqualityOperator<T> 
+ *
+ * @template-extends EqualityOperator<T>
  */
 class LessThanEqual extends EqualityOperator
 {

--- a/lib/Qandidate/Toggle/Operator/MatchesRegex.php
+++ b/lib/Qandidate/Toggle/Operator/MatchesRegex.php
@@ -17,6 +17,6 @@ class MatchesRegex extends EqualityOperator
 {
     public function appliesTo($argument): bool
     {
-        return (bool) preg_match($this->value, $argument);
+        return (bool) preg_match($this->value, (string) $argument);
     }
 }

--- a/lib/Qandidate/Toggle/Operator/MatchesRegex.php
+++ b/lib/Qandidate/Toggle/Operator/MatchesRegex.php
@@ -13,10 +13,20 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+use InvalidArgumentException;
+
+
+/**
+ * @template-extends EqualityOperator<string> 
+ */
 class MatchesRegex extends EqualityOperator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
-        return (bool) preg_match($this->value, (string) $argument);
+        if (!is_string($argument)) {
+            throw new InvalidArgumentException('MatchesRegex can only be matched against strings');
+        }
+
+        return (bool) preg_match($this->value, $argument);
     }
 }

--- a/lib/Qandidate/Toggle/Operator/MatchesRegex.php
+++ b/lib/Qandidate/Toggle/Operator/MatchesRegex.php
@@ -13,18 +13,15 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
-use InvalidArgumentException;
-
-
 /**
- * @template-extends EqualityOperator<string> 
+ * @template-extends EqualityOperator<string>
  */
 class MatchesRegex extends EqualityOperator
 {
     public function appliesTo(mixed $argument): bool
     {
         if (!is_string($argument)) {
-            throw new InvalidArgumentException('MatchesRegex can only be matched against strings');
+            throw new \InvalidArgumentException('MatchesRegex can only be matched against strings');
         }
 
         return (bool) preg_match($this->value, $argument);

--- a/lib/Qandidate/Toggle/Operator/NotInSet.php
+++ b/lib/Qandidate/Toggle/Operator/NotInSet.php
@@ -15,6 +15,7 @@ namespace Qandidate\Toggle\Operator;
 
 /**
  * @template T
+ *
  * @extends InSet<T>
  */
 class NotInSet extends InSet

--- a/lib/Qandidate/Toggle/Operator/NotInSet.php
+++ b/lib/Qandidate/Toggle/Operator/NotInSet.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+/**
+ * @template T
+ * @extends InSet<T>
+ */
 class NotInSet extends InSet
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return !parent::appliesTo($argument);
     }

--- a/lib/Qandidate/Toggle/Operator/Percentage.php
+++ b/lib/Qandidate/Toggle/Operator/Percentage.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
-use InvalidArgumentException;
 use Qandidate\Toggle\Operator;
 
 class Percentage implements Operator
@@ -25,7 +24,7 @@ class Percentage implements Operator
     public function appliesTo(mixed $argument): bool
     {
         if (!is_int($argument)) {
-            throw new InvalidArgumentException('Percentage only accepts integers');
+            throw new \InvalidArgumentException('Percentage only accepts integers');
         }
 
         $asPercentage = (int) $argument % 100;

--- a/lib/Qandidate/Toggle/Operator/Percentage.php
+++ b/lib/Qandidate/Toggle/Operator/Percentage.php
@@ -17,20 +17,8 @@ use Qandidate\Toggle\Operator;
 
 class Percentage extends Operator
 {
-    /**
-     * @var int
-     */
-    private $percentage;
-
-    /**
-     * @var int
-     */
-    private $shift;
-
-    public function __construct(int $percentage, int $shift = 0)
+    public function __construct(private readonly int $percentage, private readonly int $shift = 0)
     {
-        $this->percentage = $percentage;
-        $this->shift = $shift;
     }
 
     public function appliesTo($argument): bool

--- a/lib/Qandidate/Toggle/Operator/Percentage.php
+++ b/lib/Qandidate/Toggle/Operator/Percentage.php
@@ -13,16 +13,21 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Operator;
 
+use InvalidArgumentException;
 use Qandidate\Toggle\Operator;
 
-class Percentage extends Operator
+class Percentage implements Operator
 {
     public function __construct(private readonly int $percentage, private readonly int $shift = 0)
     {
     }
 
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
+        if (!is_int($argument)) {
+            throw new InvalidArgumentException('Percentage only accepts integers');
+        }
+
         $asPercentage = (int) $argument % 100;
 
         return $asPercentage >= $this->shift

--- a/lib/Qandidate/Toggle/OperatorCondition.php
+++ b/lib/Qandidate/Toggle/OperatorCondition.php
@@ -18,20 +18,12 @@ namespace Qandidate\Toggle;
  */
 class OperatorCondition extends Condition
 {
-    /** @var string */
-    private $key;
-
-    /** @var Operator */
-    private $operator;
-
     /**
      * @param string   $key      Name of the value
      * @param Operator $operator Operator to run
      */
-    public function __construct(string $key, Operator $operator)
+    public function __construct(private readonly string $key, private readonly Operator $operator)
     {
-        $this->key = $key;
-        $this->operator = $operator;
     }
 
     public function holdsFor(Context $context): bool

--- a/lib/Qandidate/Toggle/OperatorCondition.php
+++ b/lib/Qandidate/Toggle/OperatorCondition.php
@@ -16,7 +16,7 @@ namespace Qandidate\Toggle;
 /**
  * A condition based on the name of the value from the context and an operator.
  */
-class OperatorCondition extends Condition
+class OperatorCondition implements Condition
 {
     /**
      * @param string   $key      Name of the value

--- a/lib/Qandidate/Toggle/Serializer/OperatorConditionSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/OperatorConditionSerializer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Serializer;
 
-use RuntimeException;
 use Qandidate\Toggle\OperatorCondition;
 
 /**
@@ -41,7 +40,7 @@ class OperatorConditionSerializer
         $this->assertHasKey('operator', $condition);
 
         if ('operator-condition' !== $condition['name']) {
-            throw new RuntimeException(sprintf('Unable to deserialize operator with name "%s".', $condition['name']));
+            throw new \RuntimeException(sprintf('Unable to deserialize operator with name "%s".', $condition['name']));
         }
 
         $operator = $this->operatorSerializer->deserialize($condition['operator']);
@@ -52,7 +51,7 @@ class OperatorConditionSerializer
     private function assertHasKey(string $key, array $data): void
     {
         if (!array_key_exists($key, $data)) {
-            throw new RuntimeException(sprintf('Missing key "%s" in data.', $key));
+            throw new \RuntimeException(sprintf('Missing key "%s" in data.', $key));
         }
     }
 }

--- a/lib/Qandidate/Toggle/Serializer/OperatorConditionSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/OperatorConditionSerializer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Serializer;
 
+use RuntimeException;
 use Qandidate\Toggle\OperatorCondition;
 
 /**
@@ -20,14 +21,8 @@ use Qandidate\Toggle\OperatorCondition;
  */
 class OperatorConditionSerializer
 {
-    /**
-     * @var OperatorSerializer
-     */
-    private $operatorSerializer;
-
-    public function __construct(OperatorSerializer $operatorSerializer)
+    public function __construct(private readonly OperatorSerializer $operatorSerializer)
     {
-        $this->operatorSerializer = $operatorSerializer;
     }
 
     public function serialize(OperatorCondition $condition): array
@@ -46,7 +41,7 @@ class OperatorConditionSerializer
         $this->assertHasKey('operator', $condition);
 
         if ('operator-condition' !== $condition['name']) {
-            throw new \RuntimeException(sprintf('Unable to deserialize operator with name "%s".', $condition['name']));
+            throw new RuntimeException(sprintf('Unable to deserialize operator with name "%s".', $condition['name']));
         }
 
         $operator = $this->operatorSerializer->deserialize($condition['operator']);
@@ -57,7 +52,7 @@ class OperatorConditionSerializer
     private function assertHasKey(string $key, array $data): void
     {
         if (!array_key_exists($key, $data)) {
-            throw new \RuntimeException(sprintf('Missing key "%s" in data.', $key));
+            throw new RuntimeException(sprintf('Missing key "%s" in data.', $key));
         }
     }
 }

--- a/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Serializer;
 
-use RuntimeException;
 use Qandidate\Toggle\Operator;
 use Qandidate\Toggle\Operator\EqualTo;
 use Qandidate\Toggle\Operator\GreaterThan;
@@ -55,7 +54,7 @@ class OperatorSerializer
             case MatchesRegex::class:
                 return ['name' => 'matches-regex', 'value' => $operator->getValue()];
             default:
-                throw new RuntimeException(sprintf('Unknown operator %s.', $operator::class));
+                throw new \RuntimeException(sprintf('Unknown operator %s.', $operator::class));
         }
     }
 
@@ -107,14 +106,14 @@ class OperatorSerializer
 
                 return new MatchesRegex($operator['value']);
             default:
-                throw new RuntimeException(sprintf('Unknown operator with name "%s".', $operator['name']));
+                throw new \RuntimeException(sprintf('Unknown operator with name "%s".', $operator['name']));
         }
     }
 
     private function assertHasKey(string $key, array $data): void
     {
         if (!array_key_exists($key, $data)) {
-            throw new RuntimeException(sprintf('Missing key "%s" in data.', $key));
+            throw new \RuntimeException(sprintf('Missing key "%s" in data.', $key));
         }
     }
 }

--- a/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/OperatorSerializer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Serializer;
 
+use RuntimeException;
 use Qandidate\Toggle\Operator;
 use Qandidate\Toggle\Operator\EqualTo;
 use Qandidate\Toggle\Operator\GreaterThan;
@@ -32,7 +33,7 @@ class OperatorSerializer
 {
     public function serialize(Operator $operator): array
     {
-        switch (get_class($operator)) {
+        switch ($operator::class) {
             case EqualTo::class:
                 return ['name' => 'equal-to', 'value' => $operator->getValue()];
             case GreaterThan::class:
@@ -54,7 +55,7 @@ class OperatorSerializer
             case MatchesRegex::class:
                 return ['name' => 'matches-regex', 'value' => $operator->getValue()];
             default:
-                throw new \RuntimeException(sprintf('Unknown operator %s.', get_class($operator)));
+                throw new RuntimeException(sprintf('Unknown operator %s.', $operator::class));
         }
     }
 
@@ -106,14 +107,14 @@ class OperatorSerializer
 
                 return new MatchesRegex($operator['value']);
             default:
-                throw new \RuntimeException(sprintf('Unknown operator with name "%s".', $operator['name']));
+                throw new RuntimeException(sprintf('Unknown operator with name "%s".', $operator['name']));
         }
     }
 
     private function assertHasKey(string $key, array $data): void
     {
         if (!array_key_exists($key, $data)) {
-            throw new \RuntimeException(sprintf('Missing key "%s" in data.', $key));
+            throw new RuntimeException(sprintf('Missing key "%s" in data.', $key));
         }
     }
 }

--- a/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Serializer;
 
+use RuntimeException;
+use InvalidArgumentException;
 use Qandidate\Toggle\OperatorCondition;
 use Qandidate\Toggle\Toggle;
 
@@ -21,14 +23,8 @@ use Qandidate\Toggle\Toggle;
  */
 class ToggleSerializer
 {
-    /**
-     * @var OperatorConditionSerializer
-     */
-    private $operatorConditionSerializer;
-
-    public function __construct(OperatorConditionSerializer $operatorConditionSerializer)
+    public function __construct(private readonly OperatorConditionSerializer $operatorConditionSerializer)
     {
-        $this->operatorConditionSerializer = $operatorConditionSerializer;
     }
 
     public function serialize(Toggle $toggle): array
@@ -47,7 +43,7 @@ class ToggleSerializer
         $this->assertHasKey('conditions', $data);
 
         if (!is_array($data['conditions'])) {
-            throw new \RuntimeException('Key "conditions" should be an array.');
+            throw new RuntimeException('Key "conditions" should be an array.');
         }
 
         $toggle = new Toggle(
@@ -69,7 +65,7 @@ class ToggleSerializer
 
         foreach ($conditions as $condition) {
             if (!$condition instanceof OperatorCondition) {
-                throw new \RuntimeException(sprintf('Unable to serialize %s.', get_class($condition)));
+                throw new RuntimeException(sprintf('Unable to serialize %s.', $condition::class));
             }
 
             $serialized[] = $this->operatorConditionSerializer->serialize($condition);
@@ -91,16 +87,12 @@ class ToggleSerializer
 
     private function serializeStatus(Toggle $toggle): string
     {
-        switch ($toggle->getStatus()) {
-            case Toggle::ALWAYS_ACTIVE:
-                return 'always-active';
-            case Toggle::INACTIVE:
-                return 'inactive';
-            case Toggle::CONDITIONALLY_ACTIVE:
-                return 'conditionally-active';
-        }
-
-        throw new \InvalidArgumentException('unsupported status');
+        return match ($toggle->getStatus()) {
+            Toggle::ALWAYS_ACTIVE => 'always-active',
+            Toggle::INACTIVE => 'inactive',
+            Toggle::CONDITIONALLY_ACTIVE => 'conditionally-active',
+            default => throw new InvalidArgumentException('unsupported status'),
+        };
     }
 
     private function deserializeStatus(Toggle $toggle, string $status): void
@@ -120,41 +112,33 @@ class ToggleSerializer
                 return;
         }
 
-        throw new \RuntimeException(sprintf('Unknown toggle status "%s".', $status));
+        throw new RuntimeException(sprintf('Unknown toggle status "%s".', $status));
     }
 
     private function serializeStrategy(Toggle $toggle): string
     {
-        switch ($toggle->getStrategy()) {
-            case Toggle::STRATEGY_AFFIRMATIVE:
-                return 'affirmative';
-            case Toggle::STRATEGY_MAJORITY:
-                return 'majority';
-            case Toggle::STRATEGY_UNANIMOUS:
-                return 'unanimous';
-        }
-
-        throw new \InvalidArgumentException('unsupported strategy');
+        return match ($toggle->getStrategy()) {
+            Toggle::STRATEGY_AFFIRMATIVE => 'affirmative',
+            Toggle::STRATEGY_MAJORITY => 'majority',
+            Toggle::STRATEGY_UNANIMOUS => 'unanimous',
+            default => throw new InvalidArgumentException('unsupported strategy'),
+        };
     }
 
     private function deserializeStrategy(string $strategy): int
     {
-        switch ($strategy) {
-            case 'affirmative':
-                return Toggle::STRATEGY_AFFIRMATIVE;
-            case 'majority':
-                return Toggle::STRATEGY_MAJORITY;
-            case 'unanimous':
-                return Toggle::STRATEGY_UNANIMOUS;
-        }
-
-        throw new \RuntimeException(sprintf('Unknown toggle strategy "%s".', $strategy));
+        return match ($strategy) {
+            'affirmative' => Toggle::STRATEGY_AFFIRMATIVE,
+            'majority' => Toggle::STRATEGY_MAJORITY,
+            'unanimous' => Toggle::STRATEGY_UNANIMOUS,
+            default => throw new RuntimeException(sprintf('Unknown toggle strategy "%s".', $strategy)),
+        };
     }
 
     private function assertHasKey(string $key, array $data): void
     {
         if (!array_key_exists($key, $data)) {
-            throw new \RuntimeException(sprintf('Missing key "%s" in data.', $key));
+            throw new RuntimeException(sprintf('Missing key "%s" in data.', $key));
         }
     }
 }

--- a/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
+++ b/lib/Qandidate/Toggle/Serializer/ToggleSerializer.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle\Serializer;
 
-use RuntimeException;
-use InvalidArgumentException;
 use Qandidate\Toggle\OperatorCondition;
 use Qandidate\Toggle\Toggle;
 
@@ -43,7 +41,7 @@ class ToggleSerializer
         $this->assertHasKey('conditions', $data);
 
         if (!is_array($data['conditions'])) {
-            throw new RuntimeException('Key "conditions" should be an array.');
+            throw new \RuntimeException('Key "conditions" should be an array.');
         }
 
         $toggle = new Toggle(
@@ -65,7 +63,7 @@ class ToggleSerializer
 
         foreach ($conditions as $condition) {
             if (!$condition instanceof OperatorCondition) {
-                throw new RuntimeException(sprintf('Unable to serialize %s.', $condition::class));
+                throw new \RuntimeException(sprintf('Unable to serialize %s.', $condition::class));
             }
 
             $serialized[] = $this->operatorConditionSerializer->serialize($condition);
@@ -91,7 +89,7 @@ class ToggleSerializer
             Toggle::ALWAYS_ACTIVE => 'always-active',
             Toggle::INACTIVE => 'inactive',
             Toggle::CONDITIONALLY_ACTIVE => 'conditionally-active',
-            default => throw new InvalidArgumentException('unsupported status'),
+            default => throw new \InvalidArgumentException('unsupported status'),
         };
     }
 
@@ -112,7 +110,7 @@ class ToggleSerializer
                 return;
         }
 
-        throw new RuntimeException(sprintf('Unknown toggle status "%s".', $status));
+        throw new \RuntimeException(sprintf('Unknown toggle status "%s".', $status));
     }
 
     private function serializeStrategy(Toggle $toggle): string
@@ -121,7 +119,7 @@ class ToggleSerializer
             Toggle::STRATEGY_AFFIRMATIVE => 'affirmative',
             Toggle::STRATEGY_MAJORITY => 'majority',
             Toggle::STRATEGY_UNANIMOUS => 'unanimous',
-            default => throw new InvalidArgumentException('unsupported strategy'),
+            default => throw new \InvalidArgumentException('unsupported strategy'),
         };
     }
 
@@ -131,14 +129,14 @@ class ToggleSerializer
             'affirmative' => Toggle::STRATEGY_AFFIRMATIVE,
             'majority' => Toggle::STRATEGY_MAJORITY,
             'unanimous' => Toggle::STRATEGY_UNANIMOUS,
-            default => throw new RuntimeException(sprintf('Unknown toggle strategy "%s".', $strategy)),
+            default => throw new \RuntimeException(sprintf('Unknown toggle strategy "%s".', $strategy)),
         };
     }
 
     private function assertHasKey(string $key, array $data): void
     {
         if (!array_key_exists($key, $data)) {
-            throw new RuntimeException(sprintf('Missing key "%s" in data.', $key));
+            throw new \RuntimeException(sprintf('Missing key "%s" in data.', $key));
         }
     }
 }

--- a/lib/Qandidate/Toggle/Toggle.php
+++ b/lib/Qandidate/Toggle/Toggle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle;
 
+use InvalidArgumentException;
 /**
  * Representation of a feature toggle.
  *
@@ -36,25 +37,15 @@ class Toggle
     /** All conditions have to be met */
     public const STRATEGY_UNANIMOUS = 3;
 
-    /** @var string */
-    private $name;
+    private int $status = self::CONDITIONALLY_ACTIVE;
 
-    /** @var Condition[] */
-    private $conditions;
-
-    /** @var int */
-    private $status = self::CONDITIONALLY_ACTIVE;
-
-    /** @var int */
-    private $strategy = self::STRATEGY_AFFIRMATIVE;
+    private readonly int $strategy;
 
     /**
      * @param Condition[] $conditions
      */
-    public function __construct(string $name, array $conditions, int $strategy = self::STRATEGY_AFFIRMATIVE)
+    public function __construct(private string $name, private readonly array $conditions, int $strategy = self::STRATEGY_AFFIRMATIVE)
     {
-        $this->name = $name;
-        $this->conditions = $conditions;
         $this->assertValidStrategy($strategy);
         $this->strategy = $strategy;
     }
@@ -72,16 +63,12 @@ class Toggle
      */
     public function activeFor(Context $context): bool
     {
-        switch ($this->status) {
-            case self::ALWAYS_ACTIVE:
-                return true;
-            case self::INACTIVE:
-                return false;
-            case self::CONDITIONALLY_ACTIVE:
-                return $this->executeCondition($context);
-        }
-
-        return false;
+        return match ($this->status) {
+            self::ALWAYS_ACTIVE => true,
+            self::INACTIVE => false,
+            self::CONDITIONALLY_ACTIVE => $this->executeCondition($context),
+            default => false,
+        };
     }
 
     /**
@@ -123,7 +110,7 @@ class Toggle
     private function assertValidActiveStatus(int $status): void
     {
         if (self::ALWAYS_ACTIVE !== $status && self::CONDITIONALLY_ACTIVE !== $status) {
-            throw new \InvalidArgumentException('No "active" status was provided.');
+            throw new InvalidArgumentException('No "active" status was provided.');
         }
     }
 
@@ -134,22 +121,18 @@ class Toggle
             self::STRATEGY_MAJORITY,
             self::STRATEGY_UNANIMOUS,
         ])) {
-            throw new \InvalidArgumentException('No supported strategy was provided.');
+            throw new InvalidArgumentException('No supported strategy was provided.');
         }
     }
 
     private function executeCondition(Context $context): bool
     {
-        switch ($this->strategy) {
-            case self::STRATEGY_AFFIRMATIVE:
-                return $this->atLeastOneConditionHolds($context);
-            case self::STRATEGY_MAJORITY:
-                return $this->moreThanHalfConditionsHold($context);
-            case self::STRATEGY_UNANIMOUS:
-                return $this->allConditionsHold($context);
-            default:
-                return false;
-        }
+        return match ($this->strategy) {
+            self::STRATEGY_AFFIRMATIVE => $this->atLeastOneConditionHolds($context),
+            self::STRATEGY_MAJORITY => $this->moreThanHalfConditionsHold($context),
+            self::STRATEGY_UNANIMOUS => $this->allConditionsHold($context),
+            default => false,
+        };
     }
 
     private function atLeastOneConditionHolds(Context $context): bool

--- a/lib/Qandidate/Toggle/Toggle.php
+++ b/lib/Qandidate/Toggle/Toggle.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle;
 
-use InvalidArgumentException;
 /**
  * Representation of a feature toggle.
  *
@@ -110,7 +109,7 @@ class Toggle
     private function assertValidActiveStatus(int $status): void
     {
         if (self::ALWAYS_ACTIVE !== $status && self::CONDITIONALLY_ACTIVE !== $status) {
-            throw new InvalidArgumentException('No "active" status was provided.');
+            throw new \InvalidArgumentException('No "active" status was provided.');
         }
     }
 
@@ -121,7 +120,7 @@ class Toggle
             self::STRATEGY_MAJORITY,
             self::STRATEGY_UNANIMOUS,
         ])) {
-            throw new InvalidArgumentException('No supported strategy was provided.');
+            throw new \InvalidArgumentException('No supported strategy was provided.');
         }
     }
 

--- a/lib/Qandidate/Toggle/ToggleCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection.php
@@ -19,16 +19,16 @@ namespace Qandidate\Toggle;
  * Abstraction to allow for different storage backends of toggles (e.g. redis,
  * sql, ...).
  */
-abstract class ToggleCollection
+interface ToggleCollection
 {
     /**
      * @return Toggle[]
      */
-    abstract public function all(): array;
+    public function all(): array;
 
-    abstract public function get(string $name): ?Toggle;
+    public function get(string $name): ?Toggle;
 
-    abstract public function set(string $name, Toggle $toggle): void;
+    public function set(string $name, Toggle $toggle): void;
 
-    abstract public function remove(string $name): void;
+    public function remove(string $name): void;
 }

--- a/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
@@ -25,7 +25,7 @@ class InMemoryCollection extends ToggleCollection
     /**
      * @var Toggle[]
      */
-    private $toggles = [];
+    private array $toggles = [];
 
     public function all(): array
     {

--- a/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/InMemoryCollection.php
@@ -20,7 +20,7 @@ use Qandidate\Toggle\ToggleCollection;
  * In memory collection useful for testing or when toggles are loaded
  * "statically" from for example configuration.
  */
-class InMemoryCollection extends ToggleCollection
+class InMemoryCollection implements ToggleCollection
 {
     /**
      * @var Toggle[]

--- a/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
@@ -20,7 +20,7 @@ use Qandidate\Toggle\ToggleCollection;
 /**
  * Collection persisted in redis using the Predis client.
  */
-class PredisCollection extends ToggleCollection
+class PredisCollection implements ToggleCollection
 {
     public function __construct(private readonly string $namespace, private readonly ClientInterface $client)
     {

--- a/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
+++ b/lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php
@@ -22,20 +22,8 @@ use Qandidate\Toggle\ToggleCollection;
  */
 class PredisCollection extends ToggleCollection
 {
-    /**
-     * @var ClientInterface
-     */
-    private $client;
-
-    /**
-     * @var string
-     */
-    private $namespace;
-
-    public function __construct(string $namespace, ClientInterface $client)
+    public function __construct(private readonly string $namespace, private readonly ClientInterface $client)
     {
-        $this->namespace = $namespace;
-        $this->client = $client;
     }
 
     public function getClient(): ClientInterface

--- a/lib/Qandidate/Toggle/ToggleManager.php
+++ b/lib/Qandidate/Toggle/ToggleManager.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle;
 
-use RuntimeException;
-use InvalidArgumentException;
 /**
  * Manages the toggles of an application.
  */
@@ -63,18 +61,18 @@ class ToggleManager
     /**
      * Rename the toggle.
      *
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function rename(string $oldName, string $newName): void
     {
         if ($this->collection->get($newName) instanceof Toggle) {
-            throw new RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, a toggle with name %2$s already exists', $oldName, $newName));
+            throw new \RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, a toggle with name %2$s already exists', $oldName, $newName));
         }
 
         $currentToggle = $this->collection->get($oldName);
 
         if (!$currentToggle instanceof Toggle) {
-            throw new RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, toggle with name %1$s does not exists', $oldName, $newName));
+            throw new \RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, toggle with name %1$s does not exists', $oldName, $newName));
         }
 
         $currentToggle->rename($newName);
@@ -94,13 +92,13 @@ class ToggleManager
     /**
      * @return Toggle toggle from manager that has given name
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function get(string $name): Toggle
     {
         $toggle = $this->collection->get($name);
         if (!$toggle instanceof Toggle) {
-            throw new InvalidArgumentException("Cannot find Toggle with name $name");
+            throw new \InvalidArgumentException("Cannot find Toggle with name $name");
         }
 
         return $toggle;

--- a/lib/Qandidate/Toggle/ToggleManager.php
+++ b/lib/Qandidate/Toggle/ToggleManager.php
@@ -13,19 +13,15 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle;
 
+use RuntimeException;
+use InvalidArgumentException;
 /**
  * Manages the toggles of an application.
  */
 class ToggleManager
 {
-    /**
-     * @var ToggleCollection
-     */
-    private $collection;
-
-    public function __construct(ToggleCollection $collection)
+    public function __construct(private readonly ToggleCollection $collection)
     {
-        $this->collection = $collection;
     }
 
     /**
@@ -67,18 +63,18 @@ class ToggleManager
     /**
      * Rename the toggle.
      *
-     * @throws \RuntimeException
+     * @throws RuntimeException
      */
     public function rename(string $oldName, string $newName): void
     {
         if (null !== $this->collection->get($newName)) {
-            throw new \RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, a toggle with name %2$s already exists', $oldName, $newName));
+            throw new RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, a toggle with name %2$s already exists', $oldName, $newName));
         }
 
         $currentToggle = $this->collection->get($oldName);
 
         if (null === $currentToggle) {
-            throw new \RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, toggle with name %1$s does not exists', $oldName, $newName));
+            throw new RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, toggle with name %1$s does not exists', $oldName, $newName));
         }
 
         $currentToggle->rename($newName);
@@ -98,13 +94,13 @@ class ToggleManager
     /**
      * @return Toggle toggle from manager that has given name
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function get(string $name): Toggle
     {
         $toggle = $this->collection->get($name);
         if (!$toggle) {
-            throw new \InvalidArgumentException("Cannot find Toggle with name $name");
+            throw new InvalidArgumentException("Cannot find Toggle with name $name");
         }
 
         return $toggle;

--- a/lib/Qandidate/Toggle/ToggleManager.php
+++ b/lib/Qandidate/Toggle/ToggleManager.php
@@ -29,7 +29,7 @@ class ToggleManager
      */
     public function active(string $name, Context $context): bool
     {
-        if (null === $toggle = $this->collection->get($name)) {
+        if (!($toggle = $this->collection->get($name)) instanceof Toggle) {
             return false;
         }
 
@@ -67,13 +67,13 @@ class ToggleManager
      */
     public function rename(string $oldName, string $newName): void
     {
-        if (null !== $this->collection->get($newName)) {
+        if ($this->collection->get($newName) instanceof Toggle) {
             throw new RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, a toggle with name %2$s already exists', $oldName, $newName));
         }
 
         $currentToggle = $this->collection->get($oldName);
 
-        if (null === $currentToggle) {
+        if (!$currentToggle instanceof Toggle) {
             throw new RuntimeException(sprintf('Could not rename toggle %1$s to %2$s, toggle with name %1$s does not exists', $oldName, $newName));
         }
 
@@ -99,7 +99,7 @@ class ToggleManager
     public function get(string $name): Toggle
     {
         $toggle = $this->collection->get($name);
-        if (!$toggle) {
+        if (!$toggle instanceof Toggle) {
             throw new InvalidArgumentException("Cannot find Toggle with name $name");
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,26 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$array of function array_intersect expects array, mixed given\\.$#"
-			count: 1
-			path: lib/Qandidate/Toggle/Operator/HasIntersection.php
-
-		-
-			message: "#^Parameter \\#1 \\$pattern of function preg_match expects string, mixed given\\.$#"
-			count: 1
-			path: lib/Qandidate/Toggle/Operator/MatchesRegex.php
-
-		-
-			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, mixed given\\.$#"
-			count: 1
-			path: lib/Qandidate/Toggle/Operator/MatchesRegex.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: lib/Qandidate/Toggle/Operator/Percentage.php
-
-		-
 			message: "#^Cannot call method getName\\(\\) on mixed\\.$#"
 			count: 1
 			path: lib/Qandidate/Toggle/ToggleCollection/PredisCollection.php

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/lib',
+    ]);
+
+    $rectorConfig->importNames();
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_73,
+        SetList::CODE_QUALITY,
+        SetList::STRICT_BOOLEANS,
+        SetList::TYPE_DECLARATION,
+    ]);
+};

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
 
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,

--- a/rector.php
+++ b/rector.php
@@ -2,20 +2,14 @@
 
 declare(strict_types=1);
 
-use Qandidate\Toggle\Operator;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\StringType;
-use Qandidate\Toggle\Operator\EqualTo;
-use Qandidate\Toggle\Operator\EqualityOperator;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
-use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/lib',
+        __DIR__ . '/test',
     ]);
 
     $rectorConfig->importNames();

--- a/rector.php
+++ b/rector.php
@@ -2,9 +2,16 @@
 
 declare(strict_types=1);
 
+use Qandidate\Toggle\Operator;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use Qandidate\Toggle\Operator\EqualTo;
+use Qandidate\Toggle\Operator\EqualityOperator;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -14,9 +21,9 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->importNames();
 
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_73,
+        LevelSetList::UP_TO_PHP_81,
+        SetList::TYPE_DECLARATION,
         SetList::CODE_QUALITY,
         SetList::STRICT_BOOLEANS,
-        SetList::TYPE_DECLARATION,
     ]);
 };

--- a/test/Qandidate/Toggle/ContextTest.php
+++ b/test/Qandidate/Toggle/ContextTest.php
@@ -18,7 +18,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function it_sets_a_value()
+    public function it_sets_a_value(): void
     {
         $context = new Context();
         $context->set('foo', 'bar');
@@ -31,7 +31,7 @@ class ContextTest extends TestCase
      *
      * @dataProvider validValues
      */
-    public function it_exposes_whether_it_has_a_value($value)
+    public function it_exposes_whether_it_has_a_value(int|string|bool|float|null $value): void
     {
         $context = new Context();
         $context->set('foo', $value);
@@ -39,7 +39,7 @@ class ContextTest extends TestCase
         $this->assertTrue($context->has('foo'));
     }
 
-    public function validValues()
+    public function validValues(): array
     {
         return [
             [42],
@@ -54,7 +54,7 @@ class ContextTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_have_a_value_that_was_never_set()
+    public function it_does_not_have_a_value_that_was_never_set(): void
     {
         $context = new Context();
 

--- a/test/Qandidate/Toggle/ExpressionConditionTest.php
+++ b/test/Qandidate/Toggle/ExpressionConditionTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle;
 
-use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 class ExpressionConditionTest extends TestCase
 {

--- a/test/Qandidate/Toggle/ExpressionConditionTest.php
+++ b/test/Qandidate/Toggle/ExpressionConditionTest.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace Qandidate\Toggle;
 
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class ExpressionConditionTest extends TestCase
 {
-    protected $language;
+    protected ExpressionLanguage $language;
 
     protected function setUp(): void
     {
@@ -27,9 +28,9 @@ class ExpressionConditionTest extends TestCase
     /**
      * @test
      */
-    public function it_should_fire_a_syntax_error_exception()
+    public function it_should_fire_a_syntax_error_exception(): void
     {
-        $this->expectException('Symfony\Component\ExpressionLanguage\SyntaxError');
+        $this->expectException(SyntaxError::class);
         $condition = new ExpressionCondition('price < 5', $this->language);
         $context = new Context();
 
@@ -39,7 +40,7 @@ class ExpressionConditionTest extends TestCase
     /**
      * @test
      */
-    public function it_should_evaluate_a_correct_expression()
+    public function it_should_evaluate_a_correct_expression(): void
     {
         $condition = new ExpressionCondition('user["active"] and product["price"] >= 25', $this->language);
         $context = new Context();
@@ -59,7 +60,7 @@ class ExpressionConditionTest extends TestCase
     /**
      * @test
      */
-    public function it_should_returns_false_if_the_conditions_are_not_met()
+    public function it_should_returns_false_if_the_conditions_are_not_met(): void
     {
         $condition = new ExpressionCondition('"bootstrap" in user["tags"]', $this->language);
         $context = new Context();
@@ -75,7 +76,7 @@ class ExpressionConditionTest extends TestCase
     /**
      * @test
      */
-    public function it_should_return_false_if_the_expression_does_not_return_boolean()
+    public function it_should_return_false_if_the_expression_does_not_return_boolean(): void
     {
         $condition = new ExpressionCondition('user["tags"]', $this->language);
         $context = new Context();

--- a/test/Qandidate/Toggle/Operator/EqualToOperatorTest.php
+++ b/test/Qandidate/Toggle/Operator/EqualToOperatorTest.php
@@ -22,13 +22,13 @@ class EqualToOperatorTest extends TestCase
      *
      * @dataProvider integerValues
      */
-    public function it_applies_to_integer_values($value, $argument)
+    public function it_applies_to_integer_values(int $value, int $argument): void
     {
         $operator = new EqualTo($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function integerValues()
+    public function integerValues(): array
     {
         return [
             [0,  0],
@@ -42,13 +42,13 @@ class EqualToOperatorTest extends TestCase
      *
      * @dataProvider stringValues
      */
-    public function it_applies_to_string_values($value, $argument)
+    public function it_applies_to_string_values(string $value, string $argument): void
     {
         $operator = new EqualTo($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function stringValues()
+    public function stringValues(): array
     {
         return [
             ['foo', 'foo'],
@@ -62,13 +62,13 @@ class EqualToOperatorTest extends TestCase
      *
      * @dataProvider floatValues
      */
-    public function it_applies_to_float_values($value, $argument)
+    public function it_applies_to_float_values(float $value, float $argument): void
     {
         $operator = new EqualTo($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function floatValues()
+    public function floatValues(): array
     {
         return [
             [3.14, 3.14],
@@ -81,13 +81,13 @@ class EqualToOperatorTest extends TestCase
      *
      * @dataProvider notEqualValues
      */
-    public function it_does_not_apply_to_not_equal_values($value, $argument)
+    public function it_does_not_apply_to_not_equal_values(int|float|bool|string|null $value, int|float $argument): void
     {
         $operator = new EqualTo($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function notEqualValues()
+    public function notEqualValues(): array
     {
         return [
             [42,   43],
@@ -103,7 +103,7 @@ class EqualToOperatorTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new EqualTo(42);
         $this->assertEquals(42, $operator->getValue());

--- a/test/Qandidate/Toggle/Operator/GreaterThanEqualOperatorTest.php
+++ b/test/Qandidate/Toggle/Operator/GreaterThanEqualOperatorTest.php
@@ -22,13 +22,13 @@ class GreaterThanEqualOperatorTest extends TestCase
      *
      * @dataProvider greaterValues
      */
-    public function it_applies_to_greater_values($value, $argument)
+    public function it_applies_to_greater_values(int|float $value, int|float $argument): void
     {
         $operator = new GreaterThanEqual($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function greaterValues()
+    public function greaterValues(): array
     {
         return [
             [42,  43],
@@ -43,13 +43,13 @@ class GreaterThanEqualOperatorTest extends TestCase
      *
      * @dataProvider equalValues
      */
-    public function it_does_applies_to_equal_values($value, $argument)
+    public function it_does_applies_to_equal_values(int|float $value, int|float $argument): void
     {
         $operator = new GreaterThanEqual($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function equalValues()
+    public function equalValues(): array
     {
         return [
             [42,   42],
@@ -63,13 +63,13 @@ class GreaterThanEqualOperatorTest extends TestCase
      *
      * @dataProvider smallerValues
      */
-    public function it_does_not_apply_to_smaller_values($value, $argument)
+    public function it_does_not_apply_to_smaller_values(int|float $value, int|float $argument): void
     {
         $operator = new GreaterThanEqual($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function smallerValues()
+    public function smallerValues(): array
     {
         return [
             [43,   42],
@@ -82,7 +82,7 @@ class GreaterThanEqualOperatorTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new GreaterThanEqual(42);
         $this->assertEquals(42, $operator->getValue());

--- a/test/Qandidate/Toggle/Operator/GreaterThanOperatorTest.php
+++ b/test/Qandidate/Toggle/Operator/GreaterThanOperatorTest.php
@@ -22,13 +22,13 @@ class GreaterThanOperatorTest extends TestCase
      *
      * @dataProvider greaterValues
      */
-    public function it_applies_to_greater_values($value, $argument)
+    public function it_applies_to_greater_values(int|float $value, int|float $argument): void
     {
         $operator = new GreaterThan($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function greaterValues()
+    public function greaterValues(): array
     {
         return [
             [42,  43],
@@ -43,13 +43,13 @@ class GreaterThanOperatorTest extends TestCase
      *
      * @dataProvider equalValues
      */
-    public function it_does_not_apply_to_equal_values($value, $argument)
+    public function it_does_not_apply_to_equal_values(int|float $value, int|float $argument): void
     {
         $operator = new GreaterThan($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function equalValues()
+    public function equalValues(): array
     {
         return [
             [42,   42],
@@ -63,13 +63,13 @@ class GreaterThanOperatorTest extends TestCase
      *
      * @dataProvider smallerValues
      */
-    public function it_does_not_apply_to_smaller_values($value, $argument)
+    public function it_does_not_apply_to_smaller_values(int|float $value, int|float $argument): void
     {
         $operator = new GreaterThan($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function smallerValues()
+    public function smallerValues(): array
     {
         return [
             [43,   42],
@@ -82,7 +82,7 @@ class GreaterThanOperatorTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new GreaterThan(42);
         $this->assertEquals(42, $operator->getValue());

--- a/test/Qandidate/Toggle/Operator/HasIntersectionTest.php
+++ b/test/Qandidate/Toggle/Operator/HasIntersectionTest.php
@@ -22,13 +22,13 @@ class HasIntersectionTest extends TestCase
      *
      * @dataProvider valuesNotMatching
      */
-    public function it_not_applies_to_set_not_matching_values($values, $argument)
+    public function it_not_applies_to_set_not_matching_values(array $values, array $argument): void
     {
         $operator = new HasIntersection($values);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function valuesNotMatching()
+    public function valuesNotMatching(): array
     {
         return [
             [[4],     [1, 2, 3]],
@@ -42,13 +42,13 @@ class HasIntersectionTest extends TestCase
      *
      * @dataProvider valuesMatching
      */
-    public function it_applies_to_set_matching_values($values, $argument)
+    public function it_applies_to_set_matching_values(array $values, array $argument): void
     {
         $operator = new HasIntersection($values);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function valuesMatching()
+    public function valuesMatching(): array
     {
         return [
             [[1],     [1, 2, 3]],
@@ -61,7 +61,7 @@ class HasIntersectionTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new HasIntersection(['a', 'b', 'c']);
         $this->assertEquals(['a', 'b', 'c'], $operator->getValues());

--- a/test/Qandidate/Toggle/Operator/InSetTest.php
+++ b/test/Qandidate/Toggle/Operator/InSetTest.php
@@ -22,13 +22,13 @@ class InSetTest extends TestCase
      *
      * @dataProvider valuesInSet
      */
-    public function it_applies_if_value_in_set($argument, $values)
+    public function it_applies_if_value_in_set(int|string $argument, array $values): void
     {
         $operator = new InSet($values);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function valuesInSet()
+    public function valuesInSet(): array
     {
         return [
             [5,     [1, 1, 2, 3, 5, 8]],
@@ -41,13 +41,13 @@ class InSetTest extends TestCase
      *
      * @dataProvider valuesNotInSet
      */
-    public function it_does_not_apply_if_value_not_in_set($argument, $set)
+    public function it_does_not_apply_if_value_not_in_set(int|string $argument, array $set): void
     {
         $operator = new InSet($set);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function valuesNotInSet()
+    public function valuesNotInSet(): array
     {
         return [
             [5,     [1, 1, 2, 3]],
@@ -60,13 +60,13 @@ class InSetTest extends TestCase
      *
      * @dataProvider nullSets
      */
-    public function it_never_accepts_null_as_part_of_a_set($argument, $set)
+    public function it_never_accepts_null_as_part_of_a_set(mixed $argument, array $set): void
     {
         $operator = new InSet($set);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function nullSets()
+    public function nullSets(): array
     {
         return [
             [null, [null, 1]],
@@ -77,7 +77,7 @@ class InSetTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_values()
+    public function it_exposes_its_values(): void
     {
         $values = [1, 'foo'];
         $operator = new InSet($values);

--- a/test/Qandidate/Toggle/Operator/LessThanEqualOperatorTest.php
+++ b/test/Qandidate/Toggle/Operator/LessThanEqualOperatorTest.php
@@ -22,13 +22,13 @@ class LessThanEqualOperatorTest extends TestCase
      *
      * @dataProvider greaterValues
      */
-    public function it_does_not_apply_to_greater_values($value, $argument)
+    public function it_does_not_apply_to_greater_values(int|float $value, int|float $argument): void
     {
         $operator = new LessThanEqual($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function greaterValues()
+    public function greaterValues(): array
     {
         return [
             [42,  43],
@@ -43,13 +43,13 @@ class LessThanEqualOperatorTest extends TestCase
      *
      * @dataProvider equalValues
      */
-    public function it_applies_to_equal_values($value, $argument)
+    public function it_applies_to_equal_values(int|float $value, int|float $argument): void
     {
         $operator = new LessThanEqual($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function equalValues()
+    public function equalValues(): array
     {
         return [
             [42,   42],
@@ -63,13 +63,13 @@ class LessThanEqualOperatorTest extends TestCase
      *
      * @dataProvider smallerValues
      */
-    public function it_applies_to_smaller_values($value, $argument)
+    public function it_applies_to_smaller_values(int|float $value, int|float $argument): void
     {
         $operator = new LessThanEqual($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function smallerValues()
+    public function smallerValues(): array
     {
         return [
             [43,   42],
@@ -82,7 +82,7 @@ class LessThanEqualOperatorTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new LessThanEqual(42);
         $this->assertEquals(42, $operator->getValue());

--- a/test/Qandidate/Toggle/Operator/LessThanOperatorTest.php
+++ b/test/Qandidate/Toggle/Operator/LessThanOperatorTest.php
@@ -22,13 +22,13 @@ class LessThanOperatorTest extends TestCase
      *
      * @dataProvider greaterValues
      */
-    public function it_does_not_apply_to_greater_values($value, $argument)
+    public function it_does_not_apply_to_greater_values(int|float $value, int|float $argument): void
     {
         $operator = new LessThan($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function greaterValues()
+    public function greaterValues(): array
     {
         return [
             [42,  43],
@@ -43,13 +43,13 @@ class LessThanOperatorTest extends TestCase
      *
      * @dataProvider equalValues
      */
-    public function it_does_not_apply_to_equal_values($value, $argument)
+    public function it_does_not_apply_to_equal_values(int|float $value, int|float $argument): void
     {
         $operator = new LessThan($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function equalValues()
+    public function equalValues(): array
     {
         return [
             [42,   42],
@@ -63,13 +63,13 @@ class LessThanOperatorTest extends TestCase
      *
      * @dataProvider smallerValues
      */
-    public function it_applies_to_smaller_values($value, $argument)
+    public function it_applies_to_smaller_values(int|float $value, int|float $argument): void
     {
         $operator = new LessThan($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function smallerValues()
+    public function smallerValues(): array
     {
         return [
             [43,   42],
@@ -82,7 +82,7 @@ class LessThanOperatorTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new LessThan(42);
         $this->assertEquals(42, $operator->getValue());

--- a/test/Qandidate/Toggle/Operator/MatchesRegexOperatorTest.php
+++ b/test/Qandidate/Toggle/Operator/MatchesRegexOperatorTest.php
@@ -22,13 +22,13 @@ class MatchesRegexOperatorTest extends TestCase
      *
      * @dataProvider stringBeginningWith
      */
-    public function it_applies_to_strings_matching_regex($value, $argument)
+    public function it_applies_to_strings_matching_regex(string $value, string $argument): void
     {
         $operator = new MatchesRegex($value);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function stringBeginningWith()
+    public function stringBeginningWith(): array
     {
         return [
             ['/@foobar.com/',  'barbaz@foobar.com'],
@@ -40,13 +40,13 @@ class MatchesRegexOperatorTest extends TestCase
      *
      * @dataProvider stringNotContaining
      */
-    public function it_does_not_apply_to_strings_not_matching_regex($value, $argument)
+    public function it_does_not_apply_to_strings_not_matching_regex(string $value, string $argument): void
     {
         $operator = new MatchesRegex($value);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function stringNotContaining()
+    public function stringNotContaining(): array
     {
         return [
             ['/^@foobar.com/', 'barbaz@foobar.net'],
@@ -56,7 +56,7 @@ class MatchesRegexOperatorTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_value()
+    public function it_exposes_its_value(): void
     {
         $operator = new MatchesRegex('/^@foobar.com/');
         $this->assertEquals('/^@foobar.com/', $operator->getValue());

--- a/test/Qandidate/Toggle/Operator/NotInSetTest.php
+++ b/test/Qandidate/Toggle/Operator/NotInSetTest.php
@@ -22,13 +22,13 @@ class NotInSetTest extends TestCase
      *
      * @dataProvider valuesNotInSet
      */
-    public function it_applies_if_value_not_in_set($argument, $values)
+    public function it_applies_if_value_not_in_set(int|string $argument, array $values): void
     {
         $operator = new NotInSet($values);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function valuesNotInSet()
+    public function valuesNotInSet(): array
     {
         return [
             [4,     [1, 1, 2, 3, 5, 8]],
@@ -41,13 +41,13 @@ class NotInSetTest extends TestCase
      *
      * @dataProvider valuesInSet
      */
-    public function it_does_not_apply_if_value_in_set($argument, $set)
+    public function it_does_not_apply_if_value_in_set(int|string $argument, array $set): void
     {
         $operator = new NotInSet($set);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function valuesInSet()
+    public function valuesInSet(): array
     {
         return [
             [2,     [1, 1, 2, 3]],
@@ -60,13 +60,13 @@ class NotInSetTest extends TestCase
      *
      * @dataProvider nullSets
      */
-    public function it_considers_null_to_not_be_part_of_a_set($argument, $set)
+    public function it_considers_null_to_not_be_part_of_a_set(mixed $argument, array $set): void
     {
         $operator = new NotInSet($set);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function nullSets()
+    public function nullSets(): array
     {
         return [
             [null, [null, 1]],
@@ -77,7 +77,7 @@ class NotInSetTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_values()
+    public function it_exposes_its_values(): void
     {
         $values = [1, 'foo'];
         $operator = new NotInSet($values);

--- a/test/Qandidate/Toggle/Operator/PercentageTest.php
+++ b/test/Qandidate/Toggle/Operator/PercentageTest.php
@@ -22,13 +22,13 @@ class PercentageTest extends TestCase
      *
      * @dataProvider valuesInPercentage
      */
-    public function it_applies_if_value_in_percentage($percentage, $argument)
+    public function it_applies_if_value_in_percentage(int $percentage, int $argument): void
     {
         $operator = new Percentage($percentage);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function valuesInPercentage()
+    public function valuesInPercentage(): array
     {
         return [
             [5, 4],
@@ -44,13 +44,13 @@ class PercentageTest extends TestCase
      *
      * @dataProvider valuesNotInPercentage
      */
-    public function it_does_not_apply_if_value_not_in_percentage($percentage, $argument)
+    public function it_does_not_apply_if_value_not_in_percentage(int $percentage, int $argument): void
     {
         $operator = new Percentage($percentage);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function valuesNotInPercentage()
+    public function valuesNotInPercentage(): array
     {
         return [
             [5, 5],
@@ -65,13 +65,13 @@ class PercentageTest extends TestCase
      *
      * @dataProvider valuesInPercentageShifted
      */
-    public function it_applies_if_value_in_shifted_percentage($percentage, $argument)
+    public function it_applies_if_value_in_shifted_percentage(int $percentage, int $argument): void
     {
         $operator = new Percentage($percentage, 42);
         $this->assertTrue($operator->appliesTo($argument));
     }
 
-    public function valuesInPercentageShifted()
+    public function valuesInPercentageShifted(): array
     {
         return [
             [5, 46],
@@ -87,13 +87,13 @@ class PercentageTest extends TestCase
      *
      * @dataProvider valuesNotInPercentageShifted
      */
-    public function it_does_not_apply_if_value_in_shifted_percentage($percentage, $argument)
+    public function it_does_not_apply_if_value_in_shifted_percentage(int $percentage, int $argument): void
     {
         $operator = new Percentage($percentage, 42);
         $this->assertFalse($operator->appliesTo($argument));
     }
 
-    public function valuesNotInPercentageShifted()
+    public function valuesNotInPercentageShifted(): array
     {
         return [
             [5, 47],
@@ -106,7 +106,7 @@ class PercentageTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_percentage_and_shift()
+    public function it_exposes_its_percentage_and_shift(): void
     {
         $operator = new Percentage(42, 5);
 

--- a/test/Qandidate/Toggle/OperatorConditionTest.php
+++ b/test/Qandidate/Toggle/OperatorConditionTest.php
@@ -20,7 +20,7 @@ class OperatorConditionTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_false_if_context_does_not_contain_key()
+    public function it_returns_false_if_context_does_not_contain_key(): void
     {
         $condition = new OperatorCondition('age', new GreaterThan(42));
         $context = new Context();
@@ -33,7 +33,7 @@ class OperatorConditionTest extends TestCase
      *
      * @dataProvider valueAvailable
      */
-    public function it_returns_whether_it_operator_holds_for_the_value_if_available($value, $expected)
+    public function it_returns_whether_it_operator_holds_for_the_value_if_available(int $value, bool $expected): void
     {
         $condition = new OperatorCondition('age', new GreaterThan(42));
         $context = new Context();
@@ -42,7 +42,7 @@ class OperatorConditionTest extends TestCase
         $this->assertEquals($expected, $condition->holdsFor($context));
     }
 
-    public function valueAvailable()
+    public function valueAvailable(): array
     {
         return [
             [24, false],
@@ -53,7 +53,7 @@ class OperatorConditionTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_key_and_operator()
+    public function it_exposes_its_key_and_operator(): void
     {
         $key = 'age';
         $operator = new GreaterThan(42);

--- a/test/Qandidate/Toggle/Serializer/InMemoryCollectionSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/InMemoryCollectionSerializerTest.php
@@ -24,7 +24,7 @@ class InMemoryCollectionSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_unserializes_a_collection_from_an_array()
+    public function it_unserializes_a_collection_from_an_array(): void
     {
         $data = [
             [
@@ -43,14 +43,14 @@ class InMemoryCollectionSerializerTest extends TestCase
         $serializer = new InMemoryCollectionSerializer();
         $collection = $serializer->deserialize($data);
 
-        $this->assertInstanceOf('Qandidate\Toggle\Toggle', $collection->get('toggling'));
+        $this->assertInstanceOf(Toggle::class, $collection->get('toggling'));
         $this->assertCount(1, $collection->all());
     }
 
     /**
      * @test
      */
-    public function it_serializes_a_collection_to_an_array()
+    public function it_serializes_a_collection_to_an_array(): void
     {
         $collection = new InMemoryCollection();
         $operator = new LessThan(42);
@@ -71,7 +71,7 @@ class InMemoryCollectionSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_serializes_and_deserializes_a_collection()
+    public function it_serializes_and_deserializes_a_collection(): void
     {
         $collection = new InMemoryCollection();
         $operator = new LessThan(42);

--- a/test/Qandidate/Toggle/Serializer/OperatorConditionSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/OperatorConditionSerializerTest.php
@@ -21,7 +21,7 @@ class OperatorConditionSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_serializes_an_operator()
+    public function it_serializes_an_operator(): void
     {
         $serializer = $this->createOperatorConditionSerializer();
 
@@ -41,7 +41,7 @@ class OperatorConditionSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_deserializes_an_operator()
+    public function it_deserializes_an_operator(): void
     {
         $serializer = $this->createOperatorConditionSerializer();
 
@@ -58,7 +58,7 @@ class OperatorConditionSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_on_unknown_name()
+    public function it_throws_exception_on_unknown_name(): void
     {
         $this->expectException('RuntimeException');
         $serializer = $this->createOperatorConditionSerializer();
@@ -77,7 +77,7 @@ class OperatorConditionSerializerTest extends TestCase
      *
      * @dataProvider missingKeys
      */
-    public function it_throws_exception_on_missing_key($serialized)
+    public function it_throws_exception_on_missing_key(array $serialized): void
     {
         $this->expectException('RuntimeException');
         $serializer = $this->createOperatorConditionSerializer();
@@ -85,7 +85,7 @@ class OperatorConditionSerializerTest extends TestCase
         $serializer->deserialize($serialized);
     }
 
-    public function missingKeys()
+    public function missingKeys(): array
     {
         return [
             [[]],
@@ -95,7 +95,7 @@ class OperatorConditionSerializerTest extends TestCase
         ];
     }
 
-    private function createOperatorConditionSerializer()
+    private function createOperatorConditionSerializer(): OperatorConditionSerializer
     {
         $operatorSerializer = new OperatorSerializer();
 

--- a/test/Qandidate/Toggle/Serializer/OperatorSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/OperatorSerializerTest.php
@@ -28,7 +28,7 @@ class OperatorSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_on_unknown_operator()
+    public function it_throws_exception_on_unknown_operator(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Unknown operator Qandidate\Toggle\Serializer\UnknownOperator.');
@@ -42,7 +42,7 @@ class OperatorSerializerTest extends TestCase
      *
      * @dataProvider knownOperators
      */
-    public function it_serializes_known_operators($operator, $expected)
+    public function it_serializes_known_operators(GreaterThan|GreaterThanEqual|LessThan|LessThanEqual|Percentage|HasIntersection|InSet $operator, array $expected): void
     {
         $serializer = new OperatorSerializer();
 
@@ -50,7 +50,7 @@ class OperatorSerializerTest extends TestCase
         $this->assertEquals($expected, $data);
     }
 
-    public function knownOperators()
+    public function knownOperators(): array
     {
         return [
             [new GreaterThan(42), ['name' => 'greater-than', 'value' => 42]],
@@ -69,7 +69,7 @@ class OperatorSerializerTest extends TestCase
      *
      * @dataProvider knownOperators
      */
-    public function it_deserializes_known_operators($expected, $serialized)
+    public function it_deserializes_known_operators(GreaterThan|GreaterThanEqual|LessThan|LessThanEqual|Percentage|HasIntersection|InSet $expected, array $serialized): void
     {
         $serializer = new OperatorSerializer();
 
@@ -82,7 +82,7 @@ class OperatorSerializerTest extends TestCase
      *
      * @dataProvider missingKeys
      */
-    public function it_throws_an_exception_if_a_key_is_missing_from_the_data($serialized)
+    public function it_throws_an_exception_if_a_key_is_missing_from_the_data(array $serialized): void
     {
         $this->expectException('RuntimeException');
         $serializer = new OperatorSerializer();
@@ -90,7 +90,7 @@ class OperatorSerializerTest extends TestCase
         $operator = $serializer->deserialize($serialized);
     }
 
-    public function missingKeys()
+    public function missingKeys(): array
     {
         return [
             [[]],
@@ -110,7 +110,7 @@ class OperatorSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_an_exception_on_deserializing_unknown_operator()
+    public function it_throws_an_exception_on_deserializing_unknown_operator(): void
     {
         $this->expectException('RuntimeException');
         $serializer = new OperatorSerializer();
@@ -119,9 +119,9 @@ class OperatorSerializerTest extends TestCase
     }
 }
 
-class UnknownOperator extends Operator
+class UnknownOperator implements Operator
 {
-    public function appliesTo($argument): bool
+    public function appliesTo(mixed $argument): bool
     {
         return true;
     }

--- a/test/Qandidate/Toggle/Serializer/ToggleSerializerTest.php
+++ b/test/Qandidate/Toggle/Serializer/ToggleSerializerTest.php
@@ -24,7 +24,7 @@ class ToggleSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_serializes_a_toggle()
+    public function it_serializes_a_toggle(): void
     {
         $serializer = $this->createToggleSerializer();
 
@@ -53,7 +53,7 @@ class ToggleSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_deserializes_a_toggle()
+    public function it_deserializes_a_toggle(): void
     {
         $serializer = $this->createToggleSerializer();
 
@@ -81,7 +81,7 @@ class ToggleSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_on_unsupport_condition()
+    public function it_throws_exception_on_unsupport_condition(): void
     {
         $this->expectException('RuntimeException');
         $operator = new OtherCondition();
@@ -96,7 +96,7 @@ class ToggleSerializerTest extends TestCase
      *
      * @dataProvider missingKeys
      */
-    public function it_throws_exception_on_missing_key($serialized)
+    public function it_throws_exception_on_missing_key(array $serialized): void
     {
         $this->expectException('RuntimeException');
         $serializer = $this->createToggleSerializer();
@@ -104,7 +104,7 @@ class ToggleSerializerTest extends TestCase
         $serializer->deserialize($serialized);
     }
 
-    public function missingKeys()
+    public function missingKeys(): array
     {
         return [
             [[]],
@@ -121,7 +121,7 @@ class ToggleSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_if_conditions_key_is_not_an_array()
+    public function it_throws_exception_if_conditions_key_is_not_an_array(): void
     {
         $this->expectException('RuntimeException');
         $serializer = $this->createToggleSerializer();
@@ -134,7 +134,7 @@ class ToggleSerializerTest extends TestCase
      *
      * @dataProvider toggleStatuses
      */
-    public function it_serializes_all_statuses($toggle, $expectedStatus)
+    public function it_serializes_all_statuses(Toggle $toggle, string $expectedStatus): void
     {
         $serializer = $this->createToggleSerializer();
 
@@ -148,7 +148,7 @@ class ToggleSerializerTest extends TestCase
      *
      * @dataProvider toggleStatuses
      */
-    public function it_deserializes_to_the_appropriate_status($toggle)
+    public function it_deserializes_to_the_appropriate_status(Toggle $toggle): void
     {
         $serializer = $this->createToggleSerializer();
         $status = $toggle->getStatus();
@@ -159,7 +159,7 @@ class ToggleSerializerTest extends TestCase
         $this->assertEquals($status, $deserializedToggle->getStatus());
     }
 
-    public function toggleStatuses()
+    public function toggleStatuses(): array
     {
         return [
             [$this->createAlwaysActiveToggle(), 'always-active'],
@@ -171,7 +171,7 @@ class ToggleSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_on_invalid_status_data()
+    public function it_throws_exception_on_invalid_status_data(): void
     {
         $this->expectException('RuntimeException');
         $serializer = $this->createToggleSerializer();
@@ -184,7 +184,7 @@ class ToggleSerializerTest extends TestCase
      *
      * @dataProvider toggleStrategies
      */
-    public function it_serializes_all_strategies($toggle, $expectedStrategy)
+    public function it_serializes_all_strategies(Toggle $toggle, string $expectedStrategy): void
     {
         $serializer = $this->createToggleSerializer();
 
@@ -198,7 +198,7 @@ class ToggleSerializerTest extends TestCase
      *
      * @dataProvider toggleStrategies
      */
-    public function it_deserializes_to_the_appropriate_strategies($toggle)
+    public function it_deserializes_to_the_appropriate_strategies(Toggle $toggle): void
     {
         $serializer = $this->createToggleSerializer();
         $strategy = $toggle->getStrategy();
@@ -212,7 +212,7 @@ class ToggleSerializerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_on_invalid_strategy_data()
+    public function it_throws_exception_on_invalid_strategy_data(): void
     {
         $this->expectException('RuntimeException');
         $serializer = $this->createToggleSerializer();
@@ -220,7 +220,7 @@ class ToggleSerializerTest extends TestCase
         $serializer->deserialize(['name' => 'foo', 'status' => 'conditionally-active', 'strategy' => 'invalid', 'conditions' => []]);
     }
 
-    public function toggleStrategies()
+    public function toggleStrategies(): array
     {
         return [
             [$this->createAffirmativeToggle(), 'affirmative'],
@@ -229,7 +229,7 @@ class ToggleSerializerTest extends TestCase
         ];
     }
 
-    private function createToggleSerializer()
+    private function createToggleSerializer(): ToggleSerializer
     {
         $operatorSerializer = new OperatorSerializer();
         $operatorConditionSerializer = new OperatorConditionSerializer($operatorSerializer);
@@ -237,7 +237,7 @@ class ToggleSerializerTest extends TestCase
         return new ToggleSerializer($operatorConditionSerializer);
     }
 
-    private function createAlwaysActiveToggle()
+    private function createAlwaysActiveToggle(): Toggle
     {
         $toggle = new Toggle('some-feature', []);
         $toggle->activate(Toggle::ALWAYS_ACTIVE);
@@ -245,14 +245,12 @@ class ToggleSerializerTest extends TestCase
         return $toggle;
     }
 
-    private function createConditionallyActiveToggle()
+    private function createConditionallyActiveToggle(): Toggle
     {
-        $toggle = new Toggle('some-feature', []);
-
-        return $toggle;
+        return new Toggle('some-feature', []);
     }
 
-    private function createInactiveToggle()
+    private function createInactiveToggle(): Toggle
     {
         $toggle = new Toggle('some-feature', []);
         $toggle->deactivate();
@@ -260,29 +258,23 @@ class ToggleSerializerTest extends TestCase
         return $toggle;
     }
 
-    private function createAffirmativeToggle()
+    private function createAffirmativeToggle(): Toggle
     {
-        $toggle = new Toggle('some-feature', [], Toggle::STRATEGY_AFFIRMATIVE);
-
-        return $toggle;
+        return new Toggle('some-feature', [], Toggle::STRATEGY_AFFIRMATIVE);
     }
 
-    private function createMajorityToggle()
+    private function createMajorityToggle(): Toggle
     {
-        $toggle = new Toggle('some-feature', [], Toggle::STRATEGY_MAJORITY);
-
-        return $toggle;
+        return new Toggle('some-feature', [], Toggle::STRATEGY_MAJORITY);
     }
 
-    private function createUnanimousToggle()
+    private function createUnanimousToggle(): Toggle
     {
-        $toggle = new Toggle('some-feature', [], Toggle::STRATEGY_UNANIMOUS);
-
-        return $toggle;
+        return new Toggle('some-feature', [], Toggle::STRATEGY_UNANIMOUS);
     }
 }
 
-class OtherCondition extends Condition
+class OtherCondition implements Condition
 {
     public function holdsFor(Context $context): bool
     {

--- a/test/Qandidate/Toggle/ToggleCollection/InMemoryCollectionTest.php
+++ b/test/Qandidate/Toggle/ToggleCollection/InMemoryCollectionTest.php
@@ -17,7 +17,7 @@ use Qandidate\Toggle\ToggleCollectionTest;
 
 class InMemoryCollectionTest extends ToggleCollectionTest
 {
-    protected function createCollection()
+    protected function createCollection(): InMemoryCollection
     {
         return new InMemoryCollection();
     }

--- a/test/Qandidate/Toggle/ToggleCollection/PredisCollectionTest.php
+++ b/test/Qandidate/Toggle/ToggleCollection/PredisCollectionTest.php
@@ -42,7 +42,7 @@ class PredisCollectionTest extends ToggleCollectionTest
         }
     }
 
-    public function createCollection()
+    public function createCollection(): PredisCollection
     {
         return $this->collection;
     }

--- a/test/Qandidate/Toggle/ToggleCollection/PredisCollectionTest.php
+++ b/test/Qandidate/Toggle/ToggleCollection/PredisCollectionTest.php
@@ -19,8 +19,8 @@ use Qandidate\Toggle\ToggleCollectionTest;
 
 class PredisCollectionTest extends ToggleCollectionTest
 {
-    private $client;
-    private $collection;
+    private Client $client;
+    private PredisCollection $collection;
 
     public function setUp(): void
     {
@@ -28,7 +28,7 @@ class PredisCollectionTest extends ToggleCollectionTest
         $this->collection = new PredisCollection('toggle_predis_test', $this->client);
         try {
             $this->client->connect();
-        } catch (ConnectionException $e) {
+        } catch (ConnectionException) {
             $this->markTestSkipped('Failed to connect to redis.');
         }
     }

--- a/test/Qandidate/Toggle/ToggleCollectionTest.php
+++ b/test/Qandidate/Toggle/ToggleCollectionTest.php
@@ -18,7 +18,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_null_if_toggle_not_in_collection()
+    public function it_returns_null_if_toggle_not_in_collection(): void
     {
         $collection = $this->createCollection();
         $this->assertNull($collection->get('some-feature'));
@@ -27,7 +27,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_set_toggle()
+    public function it_returns_a_set_toggle(): void
     {
         $toggle = new Toggle('some-feature', []);
         $collection = $this->createCollection();
@@ -39,7 +39,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_removes_a_toggle()
+    public function it_removes_a_toggle(): void
     {
         $toggle = new Toggle('some-feature', []);
         $collection = $this->createCollection();
@@ -53,7 +53,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_complain_when_removing_a_non_existing_toggle()
+    public function it_does_not_complain_when_removing_a_non_existing_toggle(): void
     {
         $collection = $this->createCollection();
 
@@ -65,7 +65,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_all_toggles()
+    public function it_exposes_all_toggles(): void
     {
         $toggle = new Toggle('some-feature', []);
         $toggle2 = new Toggle('some-other-feature', []);
@@ -83,7 +83,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_removes_existing_toggle()
+    public function it_removes_existing_toggle(): void
     {
         $toggle = new Toggle('some-feature', []);
         $collection = $this->createCollection();
@@ -99,7 +99,7 @@ abstract class ToggleCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_throw_when_removing_non_existing_toggle()
+    public function it_does_not_throw_when_removing_non_existing_toggle(): void
     {
         $collection = $this->createCollection();
 

--- a/test/Qandidate/Toggle/ToggleManagerTest.php
+++ b/test/Qandidate/Toggle/ToggleManagerTest.php
@@ -20,7 +20,7 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_false_if_toggle_not_added_to_manager_before()
+    public function it_returns_false_if_toggle_not_added_to_manager_before(): void
     {
         $manager = new ToggleManager(new InMemoryCollection());
 
@@ -30,10 +30,10 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_the_value_of_the_toggle_if_available()
+    public function it_returns_the_value_of_the_toggle_if_available(): void
     {
         $manager = new ToggleManager(new InMemoryCollection());
-        $manager->add($this->createToggleMock());
+        $manager->add($this->createToggle());
 
         $this->assertTrue($manager->active('some-feature', new Context()));
     }
@@ -41,11 +41,11 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_updates_a_toggle()
+    public function it_updates_a_toggle(): void
     {
         $manager = new ToggleManager(new InMemoryCollection());
-        $manager->add($this->createToggleMock());
-        $manager->update($this->createToggleMock(false));
+        $manager->add($this->createToggle());
+        $manager->update($this->createToggle(false));
 
         $this->assertFalse($manager->active('some-feature', new Context()));
     }
@@ -53,11 +53,11 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_removes_a_toggle()
+    public function it_removes_a_toggle(): void
     {
         $manager = new ToggleManager(new InMemoryCollection());
 
-        $manager->add($this->createToggleMock());
+        $manager->add($this->createToggle());
 
         $manager->remove('some-feature');
         $this->assertFalse($manager->active('some-feature', new Context()));
@@ -66,21 +66,11 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_renames_a_toggle()
+    public function it_renames_a_toggle(): void
     {
         $manager = new ToggleManager(new InMemoryCollection());
 
-        $toggle = $this->createToggleMock();
-
-        $manager->add($toggle);
-
-        $toggle->expects($this->once())
-            ->method('rename')
-            ->with('other-feature');
-
-        $toggle->expects($this->at(1))
-            ->method('getName')
-            ->will($this->returnValue('other-feature'));
+        $manager->add($this->createToggle());
 
         $manager->rename('some-feature', 'other-feature');
         $this->assertFalse($manager->active('some-feature', new Context()));
@@ -90,13 +80,13 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_if_new_name_is_already_in_use()
+    public function it_throws_if_new_name_is_already_in_use(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Could not rename toggle foo to some-feature, a toggle with name some-feature already exists');
         $manager = new ToggleManager(new InMemoryCollection());
 
-        $toggle = $this->createToggleMock();
+        $toggle = $this->createToggle();
 
         $manager->add($toggle);
 
@@ -106,7 +96,7 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_when_to_be_renamed_toggle_doesnt_exists()
+    public function it_throws_when_to_be_renamed_toggle_doesnt_exists(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Could not rename toggle foo to some-feature, toggle with name foo does not exists');
@@ -117,7 +107,7 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_all_toggles()
+    public function it_exposes_all_toggles(): void
     {
         $toggle = new Toggle('some-feature', []);
         $toggle2 = new Toggle('some-other-feature', []);
@@ -136,7 +126,7 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_when_given_name_does_not_exists()
+    public function it_throws_when_given_name_does_not_exists(): void
     {
         $this->expectException('InvalidArgumentException');
         $collection = new InMemoryCollection();
@@ -149,7 +139,7 @@ class ToggleManagerTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_toggle_if_toggle_with_given_name_exists()
+    public function it_returns_toggle_if_toggle_with_given_name_exists(): void
     {
         $collection = new InMemoryCollection();
         $collection->set('foo', new Toggle('foo-feature', []));
@@ -159,18 +149,14 @@ class ToggleManagerTest extends TestCase
         $this->assertInstanceOf(Toggle::class, $actual);
     }
 
-    public function createToggleMock($active = true, $getName = 'some-feature')
+    public function createToggle(bool $active = true, string $name = 'some-feature'): Toggle
     {
-        $toggleMock = $this->createMock('Qandidate\Toggle\Toggle');
+        $toggleStub = new Toggle($name, [], Toggle::STRATEGY_UNANIMOUS);
+        $toggleStub->deactivate();
+        if ($active) {
+            $toggleStub->activate(Toggle::ALWAYS_ACTIVE);
+        }
 
-        $toggleMock->expects($this->any())
-            ->method('activeFor')
-            ->will($this->returnValue($active));
-
-        $toggleMock->expects($this->at(0))
-            ->method('getName')
-            ->will($this->returnValue($getName));
-
-        return $toggleMock;
+        return $toggleStub;
     }
 }

--- a/test/Qandidate/Toggle/ToggleTest.php
+++ b/test/Qandidate/Toggle/ToggleTest.php
@@ -21,7 +21,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_active_if_one_of_the_conditions_holds_in_affirmative_strategy()
+    public function it_is_active_if_one_of_the_conditions_holds_in_affirmative_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -39,7 +39,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_inactive_if_none_of_the_conditions_hold_in_affirmative_strategy()
+    public function it_is_inactive_if_none_of_the_conditions_hold_in_affirmative_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -57,7 +57,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_active_if_more_than_half_of_the_conditions_hold_in_majority_strategy()
+    public function it_is_active_if_more_than_half_of_the_conditions_hold_in_majority_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -78,7 +78,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_inactive_if_more_than_half_of_the_conditions_do_not_hold_in_majority_strategy()
+    public function it_is_inactive_if_more_than_half_of_the_conditions_do_not_hold_in_majority_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -99,7 +99,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_inactive_if_exactly_half_of_the_conditions_hold_in_majority_strategy()
+    public function it_is_inactive_if_exactly_half_of_the_conditions_hold_in_majority_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -118,7 +118,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_active_if_all_the_conditions_hold_in_unanimous_strategy()
+    public function it_is_active_if_all_the_conditions_hold_in_unanimous_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -137,7 +137,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_is_inactive_if_one_of_the_conditions_do_not_hold_in_unanimous_strategy()
+    public function it_is_inactive_if_one_of_the_conditions_do_not_hold_in_unanimous_strategy(): void
     {
         $conditions = [
             new OperatorCondition('age', new LessThan(42)),
@@ -156,7 +156,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_name()
+    public function it_exposes_its_name(): void
     {
         $toggle = new Toggle('some-feature', []);
 
@@ -166,7 +166,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_conditions()
+    public function it_exposes_its_conditions(): void
     {
         $condition = new OperatorCondition('age', new LessThan(42));
         $condition2 = new OperatorCondition('age', new GreaterThan(42));
@@ -183,7 +183,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function its_status_is_conditionally_active_by_default()
+    public function its_status_is_conditionally_active_by_default(): void
     {
         $toggle = new Toggle('some-feature', []);
 
@@ -193,7 +193,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function its_strategy_is_affirmative_by_default()
+    public function its_strategy_is_affirmative_by_default(): void
     {
         $toggle = new Toggle('some-feature', []);
 
@@ -203,7 +203,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_can_be_always_activate()
+    public function it_can_be_always_activate(): void
     {
         $toggle = new Toggle('some-feature', []);
 
@@ -215,7 +215,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_can_be_inactive()
+    public function it_can_be_inactive(): void
     {
         $toggle = new Toggle('some-feature', []);
 
@@ -227,7 +227,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_cannot_be_activated_as_inactive()
+    public function it_cannot_be_activated_as_inactive(): void
     {
         $this->expectException('InvalidArgumentException');
         $toggle = new Toggle('some-feature', []);
@@ -238,7 +238,7 @@ class ToggleTest extends TestCase
     /**
      * @test
      */
-    public function it_cannot_be_set_with_an_non_existing_strategy()
+    public function it_cannot_be_set_with_an_non_existing_strategy(): void
     {
         $this->expectException('InvalidArgumentException');
         new Toggle('some-feature', [], -1);
@@ -249,7 +249,7 @@ class ToggleTest extends TestCase
      *
      * @dataProvider contextProvider
      */
-    public function it_is_active_for_every_context_if_activated_as_always_active($context)
+    public function it_is_active_for_every_context_if_activated_as_always_active(Context $context): void
     {
         $conditions = [
             new OperatorCondition('age', new GreaterThan(42)),
@@ -266,7 +266,7 @@ class ToggleTest extends TestCase
      *
      * @dataProvider contextProvider
      */
-    public function it_is_not_active_for_every_context_if_inactivated($context)
+    public function it_is_not_active_for_every_context_if_inactivated(Context $context): void
     {
         $conditions = [
             new OperatorCondition('age', new GreaterThan(42)),
@@ -278,7 +278,7 @@ class ToggleTest extends TestCase
         $this->assertFalse($toggle->activeFor($context));
     }
 
-    public function contextProvider()
+    public function contextProvider(): array
     {
         return [
             [$this->createContext(['age' => 1337])],
@@ -286,7 +286,7 @@ class ToggleTest extends TestCase
         ];
     }
 
-    private function createContext(array $properties)
+    private function createContext(array $properties): Context
     {
         $context = new Context();
 


### PR DESCRIPTION
Proposal to make some changes and tag as 3.0 eventually?

I'll need to make a better changelog, but some of the changes:

- PHP requirement to >= 8.1
- From abstract classes to interfaces 
- Types for everybody
- Got rid of mocks
- Used rector to make it easier

Some stuff I still would like to check:
- [ ] The `@template T` stuff I added is incomplete and I'm not even sure it's doing what I want right now.
- [ ] Related to the above; update examples to include some type checks with PHPStan
- [ ] Use `readonly`
- [ ] Update Symfony versions
- [ ] Update other dependencies where applicable